### PR TITLE
Normalize story task order by canvas coordinates and include missing tasks; add tests

### DIFF
--- a/src/features/canvas/core/services/StoryLayoutService.test.ts
+++ b/src/features/canvas/core/services/StoryLayoutService.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { StoryElement } from '../../elements/StoryElement.ts';
+import { TaskElement } from '../../elements/TaskElement.ts';
+import { StoryLayoutService } from './StoryLayoutService.ts';
+
+describe('StoryLayoutService.getLayoutTasks', () => {
+  it('normalizes task order by canvas coordinates even when story.tasks order differs', () => {
+    const service = new StoryLayoutService();
+    const story = new StoryElement({ x: 0, y: 0, width: 760, height: 420 });
+
+    const leftTask = new TaskElement({ id: 'left', x: 36, y: 92 });
+    const rightTask = new TaskElement({ id: 'right', x: 336, y: 92 });
+
+    // Simulate backend/restored relation order that does not match coordinates.
+    story.tasks = [rightTask, leftTask];
+
+    const layoutTasks = service.getLayoutTasks(story, [leftTask, rightTask]);
+
+    expect(layoutTasks.map((task) => task.id)).toEqual(['left', 'right']);
+  });
+
+  it('includes missing in-story tasks and keeps resulting list coordinate-sorted', () => {
+    const service = new StoryLayoutService();
+    const story = new StoryElement({ x: 0, y: 0, width: 760, height: 420 });
+
+    const leftTask = new TaskElement({ id: 'left', x: 36, y: 92 });
+    const middleTask = new TaskElement({ id: 'middle', x: 186, y: 92 });
+    const rightTask = new TaskElement({ id: 'right', x: 336, y: 92 });
+
+    // `middleTask` is inside story by coordinates but absent in story.tasks refs.
+    story.tasks = [rightTask, leftTask];
+
+    const layoutTasks = service.getLayoutTasks(story, [leftTask, middleTask, rightTask]);
+
+    expect(layoutTasks.map((task) => task.id)).toEqual([
+      'left',
+      'middle',
+      'right',
+    ]);
+  });
+});

--- a/src/features/canvas/core/services/StoryLayoutService.ts
+++ b/src/features/canvas/core/services/StoryLayoutService.ts
@@ -178,11 +178,11 @@ export class StoryLayoutService {
         return a.y - b.y;
       });
 
-    if (missingInside.length > 0) {
-      ordered.push(...missingInside);
-    }
+    const combined = missingInside.length > 0
+      ? [...ordered, ...missingInside]
+      : ordered;
 
-    return ordered;
+    return this.getOrderedTasks(combined);
   }
 
   private getColumns(story: StoryElement): number {


### PR DESCRIPTION
### Motivation

- Ensure task layout for a story reflects canvas coordinates rather than the persisted `story.tasks` reference order and include any tasks that are visually inside the story but missing from the refs.

### Description

- Update `getLayoutTasks` to merge referenced tasks with any missing in-story tasks and then produce a coordinate-ordered list via `getOrderedTasks`.
- Replace the previous conditional push of `missingInside` with a combined array to guarantee a single ordering pass.
- Keep existing behavior of returning tasks inside the story when `story.tasks` is empty.
- Add `StoryLayoutService.test.ts` unit tests covering normalization of ordering and inclusion of missing in-story tasks.

### Testing

- Added Vitest unit tests at `src/features/canvas/core/services/StoryLayoutService.test.ts` targeting `getLayoutTasks` and they passed when run with `vitest`.
- Tests verify that tasks are returned in left-to-right/top-to-bottom coordinate order even when `story.tasks` order differs and that missing but inside tasks are included and ordered correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e20530d883318b38584f9be0fe25)