### PR TITLE
Consolidate HUD primitives into `ui-lib` and expose prefix-free HUD API

### DIFF
--- a/docs/CANVAS-UI-TO-UI-LIB-ANALYSIS.md
+++ b/docs/CANVAS-UI-TO-UI-LIB-ANALYSIS.md
@@ -1,0 +1,105 @@
+# Аналіз: що з `features/canvas/ui` варто винести в `ui-lib`
+
+## Короткий висновок
+
+У `canvas/ui` вже є шар досить універсальних примітивів (кнопки, інпути, дропдауни, segmented control, поля форми), які фактично дублюють роль `ui-lib` і мають потенціал для повторного використання в інших фічах. Саме вони мають бути **першою хвилею міграції**.
+
+Другим етапом можна винести складені, але все ще доменно-нейтральні патерни: керування floating/popover поведінкою, generic single-select групи, статусний селектор у вигляді абстрактного step/select контролу.
+
+Чисто canvas-специфічні речі (контекстне меню для елементів canvas, мінікарта, drag&drop-пікери сутностей з прив’язкою до координат сцени) краще залишати в модулі canvas.
+
+## Пріоритезація на винесення
+
+### P0 — винести першими (висока цінність, низький ризик)
+
+1. **HUD primitives як дизайн-системний набір**
+   - `HudButtonBase`, `HudTextButton`, `HudIconButton` — спільна логіка loading/disabled/state для кнопок.
+   - `HudInput`, `HudTextInputControl`, `HudField`, `HudFormMessage` — типовий формовий стек.
+   - `HudDropdown`, `HudDropdownItem`, `HudSurface`, `HudDivider`, `HudSegmentedControl` — базові composable UI-блоки.
+   - `hudClassNames.ts` — централізовані токени/класи стилю HUD.
+
+**Чому:** це фундаментальні універсальні building blocks без прив’язки до canvas-домену.
+
+### P1 — винести після стабілізації примітивів
+
+2. **`FloatingMenuController` як утиліту поведінки**
+   - Незалежна логіка закриття оверлею по outside click/Escape, яку використовує dropdown.
+
+3. **`SingleSelectGroup` як generic-компонент**
+   - Працює з generic типом, має інжектовані стилі та render-функції.
+   - Може бути базою для сегментованих та pill-груп у різних модулях.
+
+4. **Частини `StatusSelector` (абстрагована форма)**
+   - Як reusable “stepper + dropdown selector”, якщо винести canvas-специфічні `ElementStatus`/іконки/лейбли через конфіг.
+
+### P2 — опційно, якщо є запит від інших модулів
+
+5. **Каркас модалок (`ModalFactory`)**
+   - Базовий shell для модального контейнера та дій.
+   - Лише якщо буде уніфікація з `ui-lib` `Modal` і потрібна єдина API.
+
+6. **`NotificationContainer` (після відв’язки від canvas-стріму)**
+   - Може стати адаптером до загального toast/notification сервісу.
+
+## Що залишити в `features/canvas/ui`
+
+- `ContextMenu`, `SelectionActionMenu`, `RelatedItemsPicker`, `StatusPicker` — жорстко пов’язані зі сценою, selection та canvas-командами.
+- `MiniMap`, `CanvasNavigationDock`, `CanvasControls`, `Toolbar`, `ZoomIndicator`, `UndoRedoControls` — спеціалізована навігація/керування canvas.
+- `ExistingEntityPicker` і похідні (`ExistingTask/Goal/StoryPicker`) — доменний drag&drop-потік зі сценою, координатами та canvas-інтеграціями.
+- `EditElementModal` та confirm-модалки для canvas сутностей — доменний UX.
+
+## Де вже видно перетин із `ui-lib`
+
+- У `ui-lib` уже існують `Button`, `Input`, `Modal`, `Notification`, `SearchSelect`, `Select`, `Textarea`.
+- У canvas-пакеті є паралельний набір `Hud*` компонентів для тих самих базових задач.
+
+Це означає, що доцільно не просто “переносити файли”, а зробити **консолідацію API** з чіткою базою на `Hud*`:
+
+1. **Зафіксувати HUD як основу**: у конфліктах/дублюванні саме `Hud*` реалізації є джерелом правди.
+2. Існуючі перетини в `ui-lib` (`Button`, `Input`, `Modal`, `Notification`, `Select`, `SearchSelect`, `Textarea`) **замінювати на HUD-реалізації** або їх API/поведінку.
+3. Підтягнути відсутні можливості в загальний шар (loading-state кнопок, формові повідомлення, сегментований контрол, поведінка dropdown/floating).
+4. Дати адаптерний шар у canvas, щоб міграція була поступовою.
+
+## Рекомендований план міграції
+
+1. **Стандартизувати API в `ui-lib` на основі HUD**
+   - Додати/уніфікувати пропси для loading-state, tone/variant, розмірів, доступності так, як це реалізовано в `Hud*`.
+2. **Замінити перетинні компоненти `ui-lib` HUD-реалізаціями**
+   - Для `Button`/`Input`/`Select`/`SearchSelect`/`Modal`/`Notification` пріоритет — перенесення поведінки й стилів з `Hud*`.
+3. **Після перенесення прибрати префікс `Hud`/`HUD` у назвах**
+   - Наприклад: `HudTextButton` → `TextButton`, `HudInput` → `Input`, `HudDropdown` → `Dropdown`, `HUD_*_CLASS` → `*_CLASS`.
+4. **Зробити canvas-адаптери**
+   - Тимчасові thin wrappers у `features/canvas/ui/primitives` з реекспортом з `ui-lib`.
+5. **Поступово замінити імпорти у canvas/ui**
+   - Почати з форм/кнопок/простих меню, потім складніші контроли.
+6. **Прибрати дублікати і стабілізувати тему/токени**
+   - Перенести `hudClassNames` у загальний шар і депрефіксувати константи після стабілізації API.
+
+## Цільовий неймінг після міграції (без `Hud`/`HUD`)
+
+- Компоненти: `TextButton`, `IconButton`, `Input`, `TextInputControl`, `Field`, `FormMessage`, `Dropdown`, `DropdownItem`, `SegmentedControl`, `Surface`, `Divider`.
+- Базові класи/токени: без `HUD_` префікса, у єдиному стилі іменування `ui-lib`.
+- Перехідний період: дозволені alias-експорти (`HudTextButton` → `TextButton`) для сумісності, з подальшим видаленням.
+
+## Ризики
+
+- Роз’їзд стилів між HUD та поточними `ui-lib` компонентами.
+- Ламання UX через різну поведінку focus/hover/loading.
+- Надмірне “узагальнення” canvas-специфічних контролів, які краще залишити локальними.
+
+## Практичний список кандидатів на винесення
+
+- `src/features/canvas/ui/primitives/HudButtonBase.ts`
+- `src/features/canvas/ui/primitives/HudTextButton.ts`
+- `src/features/canvas/ui/primitives/HudIconButton.ts`
+- `src/features/canvas/ui/primitives/HudInput.ts`
+- `src/features/canvas/ui/primitives/HudTextInputControl.ts`
+- `src/features/canvas/ui/primitives/HudField.ts`
+- `src/features/canvas/ui/primitives/HudFormMessage.ts`
+- `src/features/canvas/ui/primitives/HudDropdown.ts`
+- `src/features/canvas/ui/primitives/HudDropdownItem.ts`
+- `src/features/canvas/ui/primitives/HudSegmentedControl.ts`
+- `src/features/canvas/ui/primitives/HudSurface.ts`
+- `src/features/canvas/ui/primitives/HudDivider.ts`
+- `src/features/canvas/ui/primitives/FloatingMenuController.ts`
+- `src/features/canvas/ui/components/SingleSelectGroup.ts`

--- a/src/features/canvas/ui/primitives/index.ts
+++ b/src/features/canvas/ui/primitives/index.ts
@@ -2,14 +2,14 @@ export {
   createHudIconButton,
   setHudIconButtonLoading,
   type HudIconButtonTone,
-} from './HudIconButton.ts';
+} from '../../../../ui-lib/src/hud/index.ts';
 export {
   HUD_BUTTON_CONTROLLER,
   getHudButtonController,
   type HudButtonElement,
   type HudButtonState,
   HudButtonBase,
-} from './HudButtonBase.ts';
+} from '../../../../ui-lib/src/hud/index.ts';
 export {
   createHudTextButton,
   setHudTextButtonLoading,
@@ -18,27 +18,27 @@ export {
   type HudTextButtonSize,
   type HudTextButtonElement,
   type HudTextButtonState,
-} from './HudTextButton.ts';
-export { HudDropdown } from './HudDropdown.ts';
-export { createHudDivider } from './HudDivider.ts';
-export { createHudField } from './HudField.ts';
+} from '../../../../ui-lib/src/hud/index.ts';
+export { HudDropdown } from '../../../../ui-lib/src/hud/index.ts';
+export { createHudDivider } from '../../../../ui-lib/src/hud/index.ts';
+export { createHudField } from '../../../../ui-lib/src/hud/index.ts';
 export {
   createHudFormMessage,
   type HudFormMessage,
   type HudFormMessageTone,
-} from './HudFormMessage.ts';
+} from '../../../../ui-lib/src/hud/index.ts';
 export {
   createHudDropdownItem,
   type HudDropdownItemTone,
   type HudMenuItemVariant,
-} from './HudDropdownItem.ts';
+} from '../../../../ui-lib/src/hud/index.ts';
 export {
   createHudInputBase,
   setHudInputState,
   type HudInputBaseOptions,
   type HudInputBaseState,
   type HudInputVariant,
-} from './HudInput.ts';
+} from '../../../../ui-lib/src/hud/index.ts';
 export {
   createHudInput,
   type HudInput,
@@ -46,11 +46,55 @@ export {
   createHudTextInputControl,
   type HudTextInputControl,
   type HudTextInputKind,
-} from './HudTextInputControl.ts';
+} from '../../../../ui-lib/src/hud/index.ts';
 export {
   createHudSegmentedControl,
   HudSegmentedControl,
   type HudSegmentedControlOption,
   type HudSegmentedControlSize,
-} from './HudSegmentedControl.ts';
-export { createHudSurface } from './HudSurface.ts';
+} from '../../../../ui-lib/src/hud/index.ts';
+export { createHudSurface } from '../../../../ui-lib/src/hud/index.ts';
+
+// Prefix-free exports for new code
+export {
+  createIconButton,
+  setIconButtonLoading,
+  type IconButtonTone,
+  BUTTON_CONTROLLER,
+  getButtonController,
+  type ButtonElement,
+  type ButtonState,
+  ButtonBase,
+  createTextButton,
+  setTextButtonLoading,
+  setTextButtonState,
+  type TextButtonTone,
+  type TextButtonSize,
+  type TextButtonElement,
+  type TextButtonState,
+  Dropdown,
+  createDivider,
+  createField,
+  createFormMessage,
+  type FormMessage,
+  type FormMessageTone,
+  createDropdownItem,
+  type DropdownItemTone,
+  type MenuItemVariant,
+  createInputBase,
+  setInputState,
+  type InputBaseOptions,
+  type InputBaseState,
+  type InputVariant,
+  createInput,
+  type Input,
+  type InputKind,
+  createTextInputControl,
+  type TextInputControl,
+  type TextInputKind,
+  createSegmentedControl,
+  SegmentedControl,
+  type SegmentedControlOption,
+  type SegmentedControlSize,
+  createSurface,
+} from '../../../../ui-lib/src/hud/index.ts';

--- a/src/ui-lib/src/hud/FloatingMenuController.ts
+++ b/src/ui-lib/src/hud/FloatingMenuController.ts
@@ -1,0 +1,46 @@
+type FloatingMenuControllerOptions = {
+  isOpen: () => boolean;
+  setOpen: (open: boolean) => void;
+  containsTarget: (target: Node) => boolean;
+};
+
+export class FloatingMenuController {
+  private readonly isOpen: () => boolean;
+  private readonly setOpen: (open: boolean) => void;
+  private readonly containsTarget: (target: Node) => boolean;
+  private mounted = false;
+
+  constructor(options: FloatingMenuControllerOptions) {
+    this.isOpen = options.isOpen;
+    this.setOpen = options.setOpen;
+    this.containsTarget = options.containsTarget;
+  }
+
+  public mount(): void {
+    if (this.mounted) return;
+    window.addEventListener('mousedown', this.onMouseDown);
+    window.addEventListener('keydown', this.onKeyDown);
+    this.mounted = true;
+  }
+
+  public unmount(): void {
+    if (!this.mounted) return;
+    window.removeEventListener('mousedown', this.onMouseDown);
+    window.removeEventListener('keydown', this.onKeyDown);
+    this.mounted = false;
+  }
+
+  private readonly onMouseDown = (event: MouseEvent): void => {
+    if (!this.isOpen()) return;
+    const target = event.target;
+    if (!(target instanceof Node)) return;
+    if (this.containsTarget(target)) return;
+    this.setOpen(false);
+  };
+
+  private readonly onKeyDown = (event: KeyboardEvent): void => {
+    if (!this.isOpen()) return;
+    if (event.key !== 'Escape') return;
+    this.setOpen(false);
+  };
+}

--- a/src/ui-lib/src/hud/HudButtonBase.ts
+++ b/src/ui-lib/src/hud/HudButtonBase.ts
@@ -1,0 +1,163 @@
+import { createIcon } from './icons.ts';
+
+export type HudButtonState = {
+  disabled?: boolean;
+  loading?: boolean;
+  loadingText?: string;
+};
+
+type HudButtonBaseOptions = {
+  className: string;
+  type?: 'button' | 'submit' | 'reset';
+  title?: string;
+  ariaLabel?: string;
+  onClick?: (event: MouseEvent) => void;
+};
+
+export const HUD_BUTTON_CONTROLLER = Symbol('HUD_BUTTON_CONTROLLER');
+
+export type HudButtonElement = HTMLButtonElement & {
+  loading: boolean;
+  loadingText?: string;
+  [HUD_BUTTON_CONTROLLER]?: HudButtonBase;
+};
+
+export abstract class HudButtonBase {
+  protected readonly button: HudButtonElement;
+
+  protected constructor(options: HudButtonBaseOptions) {
+    const button = document.createElement('button') as HudButtonElement;
+    button.type = options.type ?? 'button';
+    button.className = options.className;
+    if (options.title) {
+      button.title = options.title;
+    }
+    if (options.ariaLabel) {
+      button.setAttribute('aria-label', options.ariaLabel);
+    }
+    if (options.onClick) {
+      button.addEventListener('click', options.onClick);
+    }
+    this.button = button;
+    this.button[HUD_BUTTON_CONTROLLER] = this;
+    this.attachStateAccessors();
+  }
+
+  public getElement(): HudButtonElement {
+    return this.button;
+  }
+
+  protected initializeState(state: HudButtonState): void {
+    this.setState(state);
+  }
+
+  public setState(state: HudButtonState): void {
+    if (state.loadingText !== undefined) {
+      this.setStoredLoadingText(state.loadingText);
+    }
+    const loading = state.loading ?? this.isLoading();
+    if (loading) {
+      this.enterLoading();
+      return;
+    }
+    this.leaveLoading(state.disabled);
+  }
+
+  protected createSpinner(size: number = 14, strokeWidth: number = 2): SVGSVGElement {
+    const spinner = createIcon('arrow-path', { size, strokeWidth });
+    startSpinnerAnimation(spinner);
+    spinner.setAttribute('aria-hidden', 'true');
+    return spinner;
+  }
+
+  protected abstract renderLoadingContent(loadingText?: string): void;
+
+  protected onLoadingCleared(): void {}
+
+  private isLoading(): boolean {
+    return this.button.getAttribute('data-loading') === 'true';
+  }
+
+  private enterLoading(): void {
+    if (!this.isLoading()) {
+      this.button.dataset.hudRestoreHtml = this.button.innerHTML;
+      this.button.dataset.hudRestoreDisabled = this.button.disabled ? 'true' : 'false';
+    }
+    this.button.setAttribute('data-loading', 'true');
+    this.button.setAttribute('aria-busy', 'true');
+    this.button.setAttribute('aria-disabled', 'true');
+    this.button.disabled = true;
+    this.renderLoadingContent(this.getStoredLoadingText());
+  }
+
+  private leaveLoading(nextDisabled?: boolean): void {
+    const wasLoading = this.isLoading();
+    if (wasLoading && this.button.dataset.hudRestoreHtml !== undefined) {
+      this.button.innerHTML = this.button.dataset.hudRestoreHtml;
+      delete this.button.dataset.hudRestoreHtml;
+      this.onLoadingCleared();
+    }
+    this.button.removeAttribute('aria-busy');
+    this.button.removeAttribute('data-loading');
+
+    const restoreDisabled = this.button.dataset.hudRestoreDisabled === 'true';
+    const disabled =
+      nextDisabled ?? (wasLoading ? restoreDisabled : this.button.disabled);
+    this.button.disabled = disabled;
+    if (disabled) {
+      this.button.setAttribute('aria-disabled', 'true');
+    } else {
+      this.button.removeAttribute('aria-disabled');
+    }
+    delete this.button.dataset.hudRestoreDisabled;
+  }
+
+  private attachStateAccessors(): void {
+    Object.defineProperty(this.button, 'loading', {
+      get: () => this.isLoading(),
+      set: (value: unknown) => {
+        this.setState({ loading: Boolean(value) });
+      },
+      configurable: true,
+    });
+    Object.defineProperty(this.button, 'loadingText', {
+      get: () => this.getStoredLoadingText(),
+      set: (value: unknown) => {
+        if (typeof value === 'string') {
+          this.setStoredLoadingText(value);
+        } else {
+          delete this.button.dataset.hudLoadingText;
+        }
+        if (this.isLoading()) {
+          this.renderLoadingContent(this.getStoredLoadingText());
+        }
+      },
+      configurable: true,
+    });
+  }
+
+  private getStoredLoadingText(): string | undefined {
+    return this.button.dataset.hudLoadingText;
+  }
+
+  private setStoredLoadingText(value: string): void {
+    this.button.dataset.hudLoadingText = value;
+  }
+}
+
+export function getHudButtonController(
+  button: HTMLButtonElement
+): HudButtonBase | null {
+  return (button as HudButtonElement)[HUD_BUTTON_CONTROLLER] ?? null;
+}
+
+function startSpinnerAnimation(spinner: SVGSVGElement): void {
+  if (typeof spinner.animate === 'function') {
+    spinner.animate(
+      [{ transform: 'rotate(0deg)' }, { transform: 'rotate(360deg)' }],
+      { duration: 900, iterations: Infinity, easing: 'linear' }
+    );
+    return;
+  }
+  spinner.classList.add('animate-spin');
+}

--- a/src/ui-lib/src/hud/HudDivider.ts
+++ b/src/ui-lib/src/hud/HudDivider.ts
@@ -1,0 +1,28 @@
+import {
+  HUD_DIVIDER_BASE_CLASS,
+  HUD_DIVIDER_DEFAULT_TONE_CLASS,
+  HUD_DIVIDER_INSET_CLASS,
+  HUD_DIVIDER_SOFT_TONE_CLASS,
+  HUD_DIVIDER_SPACED_CLASS,
+} from './classNames.ts';
+
+export type HudDividerTone = 'default' | 'soft';
+
+type HudDividerOptions = {
+  inset?: boolean;
+  spaced?: boolean;
+  tone?: HudDividerTone;
+};
+
+export function createHudDivider(options: HudDividerOptions = {}): HTMLDivElement {
+  const divider = document.createElement('div');
+  const toneClass =
+    options.tone === 'soft'
+      ? HUD_DIVIDER_SOFT_TONE_CLASS
+      : HUD_DIVIDER_DEFAULT_TONE_CLASS;
+  const insetClass = options.inset ? HUD_DIVIDER_INSET_CLASS : '';
+  const spacedClass = options.spaced === false ? '' : HUD_DIVIDER_SPACED_CLASS;
+  divider.className =
+    `${HUD_DIVIDER_BASE_CLASS} ${toneClass} ${insetClass} ${spacedClass}`.trim();
+  return divider;
+}

--- a/src/ui-lib/src/hud/HudDropdown.ts
+++ b/src/ui-lib/src/hud/HudDropdown.ts
@@ -1,0 +1,51 @@
+import { FloatingMenuController } from './FloatingMenuController.ts';
+
+type HudDropdownOptions = {
+  container: HTMLElement;
+  panel: HTMLElement;
+  onOpenChange?: (open: boolean) => void;
+};
+
+export class HudDropdown {
+  private readonly container: HTMLElement;
+  private readonly panel: HTMLElement;
+  private readonly onOpenChange?: (open: boolean) => void;
+  private readonly menuController: FloatingMenuController;
+  private open: boolean;
+
+  constructor(options: HudDropdownOptions) {
+    this.container = options.container;
+    this.panel = options.panel;
+    this.onOpenChange = options.onOpenChange;
+    this.open = !this.panel.classList.contains('hidden');
+
+    this.menuController = new FloatingMenuController({
+      isOpen: () => this.open,
+      setOpen: (open) => this.setOpen(open),
+      containsTarget: (target) => this.container.contains(target),
+    });
+  }
+
+  public mount(): void {
+    this.menuController.mount();
+  }
+
+  public unmount(): void {
+    this.menuController.unmount();
+  }
+
+  public isOpen(): boolean {
+    return this.open;
+  }
+
+  public toggle(): void {
+    this.setOpen(!this.open);
+  }
+
+  public setOpen(open: boolean): void {
+    if (this.open === open) return;
+    this.open = open;
+    this.panel.classList.toggle('hidden', !open);
+    this.onOpenChange?.(open);
+  }
+}

--- a/src/ui-lib/src/hud/HudDropdownItem.ts
+++ b/src/ui-lib/src/hud/HudDropdownItem.ts
@@ -1,0 +1,88 @@
+import {
+  HUD_MENU_ITEM_ACCENT_CREATE_CLASS,
+  HUD_MENU_ITEM_BASE_CLASS,
+  HUD_MENU_ITEM_DANGER_CLASS,
+  HUD_MENU_ITEM_DEFAULT_CLASS,
+  HUD_MENU_ITEM_DISABLED_CLASS,
+  HUD_MENU_ITEM_EMPHASIS_CLASS,
+  HUD_MENU_ITEM_SELECTED_CLASS,
+} from './classNames.ts';
+
+export type HudMenuItemVariant =
+  | 'default'
+  | 'emphasis'
+  | 'selected'
+  | 'accent-create'
+  | 'danger';
+export type HudDropdownItemTone = 'default' | 'accent' | 'danger';
+
+type HudDropdownItemOptions = {
+  label: string;
+  variant?: HudMenuItemVariant;
+  tone?: HudDropdownItemTone;
+  active?: boolean;
+  disabled?: boolean;
+  className?: string;
+  leading?: HTMLElement | null;
+  trailing?: HTMLElement | null;
+  onClick?: (event: MouseEvent) => void;
+};
+
+const classByVariant: Record<HudMenuItemVariant, string> = {
+  default: HUD_MENU_ITEM_DEFAULT_CLASS,
+  emphasis: HUD_MENU_ITEM_EMPHASIS_CLASS,
+  selected: HUD_MENU_ITEM_SELECTED_CLASS,
+  'accent-create': HUD_MENU_ITEM_ACCENT_CREATE_CLASS,
+  danger: HUD_MENU_ITEM_DANGER_CLASS,
+};
+
+const toneToVariant: Record<HudDropdownItemTone, HudMenuItemVariant> = {
+  default: 'default',
+  accent: 'accent-create',
+  danger: 'danger',
+};
+
+export function createHudDropdownItem(
+  options: HudDropdownItemOptions
+): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  const explicitVariant = options.variant;
+  const fallbackVariant = options.active
+    ? 'selected'
+    : toneToVariant[options.tone ?? 'default'];
+  const variant = explicitVariant ?? fallbackVariant;
+  button.className =
+    `${HUD_MENU_ITEM_BASE_CLASS} ${classByVariant[variant]} ${options.className ?? ''}`.trim();
+  if (variant === 'selected') {
+    button.setAttribute('aria-current', 'true');
+  }
+  if (options.disabled) {
+    button.classList.add(HUD_MENU_ITEM_DISABLED_CLASS);
+    button.disabled = true;
+    button.setAttribute('aria-disabled', 'true');
+  }
+
+  const content = document.createElement('span');
+  content.className = 'inline-flex min-w-0 items-center gap-2';
+  if (options.leading) {
+    content.appendChild(options.leading);
+  }
+
+  const label = document.createElement('span');
+  label.className = 'truncate';
+  label.textContent = options.label;
+  content.appendChild(label);
+
+  button.appendChild(content);
+
+  if (options.trailing) {
+    button.appendChild(options.trailing);
+  }
+
+  if (options.onClick) {
+    button.addEventListener('click', options.onClick);
+  }
+
+  return button;
+}

--- a/src/ui-lib/src/hud/HudField.ts
+++ b/src/ui-lib/src/hud/HudField.ts
@@ -1,0 +1,232 @@
+import {
+  HUD_FIELD_CLASS,
+  HUD_FIELD_ERROR_CLASS,
+  HUD_FIELD_HINT_CLASS,
+  HUD_FIELD_LABEL_BASE_CLASS,
+  HUD_FIELD_LABEL_DEFAULT_CLASS,
+  HUD_FIELD_LABEL_DISABLED_CLASS,
+  HUD_FIELD_LABEL_ERROR_CLASS,
+  HUD_FIELD_LABEL_MUTED_CLASS,
+  HUD_FIELD_REQUIRED_MARK_CLASS,
+} from './classNames.ts';
+
+export type HudFieldTone = 'default' | 'muted';
+
+type HudFieldOptions = {
+  label: string;
+  control?: HTMLElement;
+  className?: string;
+  tone?: HudFieldTone;
+  required?: boolean;
+  invalid?: boolean;
+  disabled?: boolean;
+  hint?: string;
+  error?: string;
+};
+
+type HudFieldState = Partial<
+  Pick<
+    HudFieldOptions,
+    'tone' | 'required' | 'invalid' | 'disabled' | 'hint' | 'error'
+  >
+>;
+
+type HudField = {
+  element: HTMLDivElement;
+  label: HTMLLabelElement;
+  controlContainer: HTMLDivElement;
+  setControl: (control: HTMLElement) => void;
+  setState: (state: HudFieldState) => void;
+};
+
+let fieldIdCounter = 0;
+
+function nextId(prefix: string): string {
+  fieldIdCounter += 1;
+  return `${prefix}-${fieldIdCounter}`;
+}
+
+function ensureControlId(control: HTMLElement): string {
+  if (control.id) return control.id;
+  const id = nextId('hud-field-control');
+  control.id = id;
+  return id;
+}
+
+function findPrimaryFormControl(control: HTMLElement): HTMLElement | null {
+  if (control.matches('input, select, textarea')) {
+    return control;
+  }
+  const nested = control.querySelector('input, select, textarea');
+  return nested instanceof HTMLElement ? nested : null;
+}
+
+function connectLabelToControl(
+  label: HTMLLabelElement,
+  control: HTMLElement
+): void {
+  const primaryControl = findPrimaryFormControl(control);
+  if (primaryControl) {
+    const controlId = ensureControlId(primaryControl);
+    label.htmlFor = controlId;
+    return;
+  }
+
+  const controlId = ensureControlId(control);
+  const labelledBy = control.getAttribute('aria-labelledby');
+  if (labelledBy && labelledBy.length > 0) {
+    label.id = labelledBy.split(/\s+/)[0] ?? labelledBy;
+  } else {
+    label.id = nextId('hud-field-label');
+  }
+  control.setAttribute('aria-labelledby', label.id);
+}
+
+function mergeDescribedBy(
+  control: HTMLElement,
+  previousManagedIds: string[],
+  nextManagedIds: string[]
+): void {
+  const existingIds = (control.getAttribute('aria-describedby') ?? '')
+    .split(/\s+/)
+    .filter(Boolean)
+    .filter((id) => !previousManagedIds.includes(id));
+
+  const finalIds = [...existingIds, ...nextManagedIds];
+  if (finalIds.length > 0) {
+    control.setAttribute('aria-describedby', finalIds.join(' '));
+  } else {
+    control.removeAttribute('aria-describedby');
+  }
+}
+
+export function createHudField(options: HudFieldOptions): HudField {
+  const element = document.createElement('div');
+  element.className = `${HUD_FIELD_CLASS} ${options.className ?? ''}`.trim();
+
+  const label = document.createElement('label');
+  const controlContainer = document.createElement('div');
+  const meta = document.createElement('div');
+  const hintId = nextId('hud-field-hint');
+  const errorId = nextId('hud-field-error');
+
+  element.append(label, controlContainer, meta);
+
+  let controlEl: HTMLElement | null = null;
+  let managedDescribedByIds: string[] = [];
+  const state: Required<
+    Pick<HudFieldOptions, 'tone' | 'required' | 'invalid' | 'disabled'>
+  > &
+    Pick<HudFieldOptions, 'hint' | 'error'> = {
+    tone: options.tone ?? 'default',
+    required: options.required ?? false,
+    invalid: options.invalid ?? false,
+    disabled: options.disabled ?? false,
+    hint: options.hint,
+    error: options.error,
+  };
+
+  const renderLabel = (): void => {
+    const labelToneClass =
+      state.invalid || Boolean(state.error)
+        ? HUD_FIELD_LABEL_ERROR_CLASS
+        : state.disabled
+          ? HUD_FIELD_LABEL_DISABLED_CLASS
+          : state.tone === 'muted'
+            ? HUD_FIELD_LABEL_MUTED_CLASS
+            : HUD_FIELD_LABEL_DEFAULT_CLASS;
+
+    label.className = `${HUD_FIELD_LABEL_BASE_CLASS} ${labelToneClass}`;
+    label.replaceChildren(document.createTextNode(options.label));
+    if (state.required) {
+      const mark = document.createElement('span');
+      mark.className = HUD_FIELD_REQUIRED_MARK_CLASS;
+      mark.textContent = '*';
+      mark.setAttribute('aria-hidden', 'true');
+      label.appendChild(mark);
+    }
+  };
+
+  const renderMeta = (): void => {
+    meta.replaceChildren();
+    const hasError = Boolean(state.error && state.error.trim().length > 0);
+    const hasHint = Boolean(state.hint && state.hint.trim().length > 0);
+
+    if (hasError) {
+      const errorEl = document.createElement('div');
+      errorEl.id = errorId;
+      errorEl.className = HUD_FIELD_ERROR_CLASS;
+      errorEl.textContent = state.error ?? '';
+      meta.appendChild(errorEl);
+    } else if (hasHint) {
+      const hintEl = document.createElement('div');
+      hintEl.id = hintId;
+      hintEl.className = HUD_FIELD_HINT_CLASS;
+      hintEl.textContent = state.hint ?? '';
+      meta.appendChild(hintEl);
+    }
+  };
+
+  const applyControlState = (): void => {
+    if (!controlEl) return;
+    const targetControl = findPrimaryFormControl(controlEl) ?? controlEl;
+    if ('disabled' in targetControl) {
+      (targetControl as HTMLInputElement).disabled = state.disabled;
+    }
+
+    const hasError = Boolean(state.error && state.error.trim().length > 0);
+    const invalid = state.invalid || hasError;
+    if (invalid) {
+      targetControl.setAttribute('aria-invalid', 'true');
+    } else {
+      targetControl.removeAttribute('aria-invalid');
+    }
+
+    const hasHint = Boolean(state.hint && state.hint.trim().length > 0);
+    const describedByIds: string[] = [];
+    if (hasError) describedByIds.push(errorId);
+    else if (hasHint) describedByIds.push(hintId);
+    mergeDescribedBy(targetControl, managedDescribedByIds, describedByIds);
+    managedDescribedByIds = describedByIds;
+
+    renderMeta();
+  };
+
+  const setControl = (control: HTMLElement): void => {
+    controlContainer.replaceChildren(control);
+    controlEl = control;
+    connectLabelToControl(label, control);
+    applyControlState();
+  };
+
+  const setState = (nextState: HudFieldState): void => {
+    if (Object.prototype.hasOwnProperty.call(nextState, 'tone')) {
+      state.tone = nextState.tone ?? state.tone;
+    }
+    if (Object.prototype.hasOwnProperty.call(nextState, 'required')) {
+      state.required = nextState.required ?? state.required;
+    }
+    if (Object.prototype.hasOwnProperty.call(nextState, 'invalid')) {
+      state.invalid = nextState.invalid ?? state.invalid;
+    }
+    if (Object.prototype.hasOwnProperty.call(nextState, 'disabled')) {
+      state.disabled = nextState.disabled ?? state.disabled;
+    }
+    if (Object.prototype.hasOwnProperty.call(nextState, 'hint')) {
+      state.hint = nextState.hint;
+    }
+    if (Object.prototype.hasOwnProperty.call(nextState, 'error')) {
+      state.error = nextState.error;
+    }
+    renderLabel();
+    applyControlState();
+  };
+
+  renderLabel();
+  renderMeta();
+  if (options.control) {
+    setControl(options.control);
+  }
+
+  return { element, label, controlContainer, setControl, setState };
+}

--- a/src/ui-lib/src/hud/HudFormMessage.ts
+++ b/src/ui-lib/src/hud/HudFormMessage.ts
@@ -1,0 +1,75 @@
+export type HudFormMessageTone = 'error' | 'info' | 'success';
+
+type HudFormMessageOptions = {
+  className?: string;
+  tone?: HudFormMessageTone;
+  ariaLive?: 'polite' | 'assertive';
+};
+
+type HudFormMessageState = {
+  message?: string | null;
+  tone?: HudFormMessageTone;
+};
+
+export type HudFormMessage = {
+  element: HTMLDivElement;
+  show: (message: string, tone?: HudFormMessageTone) => void;
+  clear: () => void;
+  setState: (state: HudFormMessageState) => void;
+};
+
+const classByTone: Record<HudFormMessageTone, string> = {
+  error: 'border-rose-200 bg-rose-50 text-rose-700',
+  info: 'border-slate-200 bg-slate-50 text-slate-700',
+  success: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+};
+
+function setToneClass(
+  element: HTMLDivElement,
+  previousTone: HudFormMessageTone,
+  nextTone: HudFormMessageTone
+): void {
+  element.classList.remove(...classByTone[previousTone].split(' '));
+  element.classList.add(...classByTone[nextTone].split(' '));
+}
+
+export function createHudFormMessage(
+  options: HudFormMessageOptions = {}
+): HudFormMessage {
+  const element = document.createElement('div');
+  const baseClass = 'hidden rounded-lg border px-3 py-2.5 text-sm';
+  const tone = options.tone ?? 'error';
+  element.className =
+    `${baseClass} ${classByTone[tone]} ${options.className ?? ''}`.trim();
+  element.setAttribute('aria-live', options.ariaLive ?? 'polite');
+
+  let currentTone = tone;
+
+  const applyState = (state: HudFormMessageState): void => {
+    if (state.tone !== undefined && state.tone !== currentTone) {
+      setToneClass(element, currentTone, state.tone);
+      currentTone = state.tone;
+    }
+
+    if (state.message !== undefined) {
+      const nextMessage = state.message?.trim() ?? '';
+      if (nextMessage.length === 0) {
+        element.textContent = '';
+        element.classList.add('hidden');
+        element.removeAttribute('role');
+      } else {
+        element.textContent = nextMessage;
+        element.classList.remove('hidden');
+        element.setAttribute('role', currentTone === 'error' ? 'alert' : 'status');
+      }
+    }
+  };
+
+  return {
+    element,
+    show: (message: string, nextTone?: HudFormMessageTone) =>
+      applyState({ message, tone: nextTone }),
+    clear: () => applyState({ message: '' }),
+    setState: applyState,
+  };
+}

--- a/src/ui-lib/src/hud/HudIconButton.ts
+++ b/src/ui-lib/src/hud/HudIconButton.ts
@@ -1,0 +1,124 @@
+import {
+  HUD_ICON_BUTTON_DANGER_CLASS,
+  HUD_ICON_BUTTON_SIZE_LG_CLASS,
+  HUD_ICON_BUTTON_SIZE_MD_CLASS,
+  HUD_ICON_BUTTON_SIZE_SM_CLASS,
+  HUD_ICON_BUTTON_SECONDARY_CLASS,
+  HUD_ICON_BUTTON_TERTIARY_CLASS,
+} from './classNames.ts';
+import { createIcon, type IconName } from './icons.ts';
+import { getHudButtonController, HudButtonBase } from './HudButtonBase.ts';
+
+type HudIconButtonSize = 'sm' | 'md' | 'lg';
+export type HudIconButtonTone = 'soft' | 'secondary' | 'text' | 'danger';
+
+type HudIconButtonOptions = {
+  icon: IconName;
+  size?: HudIconButtonSize;
+  tone?: HudIconButtonTone;
+  iconSize?: number;
+  iconStrokeWidth?: number;
+  loading?: boolean;
+  className?: string;
+  title?: string;
+  ariaLabel?: string;
+  type?: 'button' | 'submit' | 'reset';
+  disabled?: boolean;
+  onClick?: (event: MouseEvent) => void;
+};
+
+const classBySize: Record<HudIconButtonSize, string> = {
+  sm: HUD_ICON_BUTTON_SIZE_SM_CLASS,
+  md: HUD_ICON_BUTTON_SIZE_MD_CLASS,
+  lg: HUD_ICON_BUTTON_SIZE_LG_CLASS,
+};
+
+const classByTone: Record<HudIconButtonTone, string> = {
+  soft: HUD_ICON_BUTTON_SECONDARY_CLASS,
+  secondary: HUD_ICON_BUTTON_SECONDARY_CLASS,
+  text: HUD_ICON_BUTTON_TERTIARY_CLASS,
+  danger: HUD_ICON_BUTTON_DANGER_CLASS,
+};
+
+const iconSizeByButtonSize: Record<HudIconButtonSize, number> = {
+  sm: 14,
+  md: 16,
+  lg: 18,
+};
+
+class HudIconButton extends HudButtonBase {
+  private loadingSize: number;
+  private loadingStrokeWidth: number;
+
+  constructor(options: HudIconButtonOptions) {
+    const buttonSize = options.size ?? 'md';
+    const tone = options.tone ?? 'soft';
+    const className =
+      `${classByTone[tone]} ${classBySize[buttonSize]} ${options.className ?? ''}`.trim();
+    super({
+      className,
+      type: options.type,
+      title: options.title,
+      ariaLabel: options.ariaLabel,
+      onClick: options.onClick,
+    });
+    const iconSize = options.iconSize ?? iconSizeByButtonSize[buttonSize];
+    this.loadingSize = iconSize;
+    this.loadingStrokeWidth = options.iconStrokeWidth ?? 2;
+
+    const icon = createIcon(options.icon, {
+      size: iconSize,
+      strokeWidth: options.iconStrokeWidth,
+    });
+    icon.setAttribute('aria-hidden', 'true');
+    this.getElement().appendChild(icon);
+
+    this.initializeState({
+      loading: options.loading ?? false,
+      disabled: options.disabled ?? false,
+    });
+  }
+
+  public setLoadingVisual(size?: number, strokeWidth?: number): void {
+    if (size !== undefined) {
+      this.loadingSize = size;
+    }
+    if (strokeWidth !== undefined) {
+      this.loadingStrokeWidth = strokeWidth;
+    }
+  }
+
+  protected renderLoadingContent(): void {
+    const element = this.getElement();
+    element.innerHTML = '';
+    element.append(this.createSpinner(this.loadingSize, this.loadingStrokeWidth));
+  }
+}
+
+export function createHudIconButton(
+  options: HudIconButtonOptions
+): HTMLButtonElement {
+  return new HudIconButton(options).getElement();
+}
+
+type HudIconButtonLoadingOptions = {
+  size?: number;
+  strokeWidth?: number;
+};
+
+export function setHudIconButtonLoading(
+  button: HTMLButtonElement,
+  loading: boolean,
+  options: HudIconButtonLoadingOptions = {}
+): void {
+  const controller = getHudButtonController(button);
+  if (controller && controller instanceof HudIconButton) {
+    controller.setLoadingVisual(options.size, options.strokeWidth);
+    controller.setState({ loading });
+    return;
+  }
+  if (!loading) {
+    button.removeAttribute('aria-busy');
+    button.removeAttribute('data-loading');
+  }
+}

--- a/src/ui-lib/src/hud/HudInput.ts
+++ b/src/ui-lib/src/hud/HudInput.ts
@@ -1,0 +1,98 @@
+import {
+  HUD_INPUT_BASE_CLASS,
+  HUD_INPUT_DEFAULT_CLASS,
+  HUD_INPUT_INLINE_CLASS,
+} from './classNames.ts';
+
+export type HudInputVariant = 'default' | 'inline';
+
+export type HudInputBaseOptions = {
+  variant?: HudInputVariant;
+  className?: string;
+  type?: string;
+  value?: string;
+  placeholder?: string;
+  name?: string;
+  id?: string;
+  autoFocus?: boolean;
+  autoComplete?: string;
+  required?: boolean;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  disabled?: boolean;
+  invalid?: boolean;
+  onInput?: (value: string, event: Event) => void;
+  onChange?: (value: string, event: Event) => void;
+  onKeyDown?: (event: KeyboardEvent) => void;
+};
+
+const classByVariant: Record<HudInputVariant, string> = {
+  default: HUD_INPUT_DEFAULT_CLASS,
+  inline: HUD_INPUT_INLINE_CLASS,
+};
+
+export function createHudInputBase(
+  options: HudInputBaseOptions = {}
+): HTMLInputElement {
+  const input = document.createElement('input');
+  input.type = options.type ?? 'text';
+  if (options.value !== undefined) input.value = options.value;
+  if (options.placeholder !== undefined) input.placeholder = options.placeholder;
+  if (options.name !== undefined) input.name = options.name;
+  if (options.id !== undefined) input.id = options.id;
+  if (options.autoFocus) input.autofocus = true;
+  if (options.autoComplete !== undefined) input.autocomplete = options.autoComplete;
+  if (options.required) input.required = true;
+  if (options.minLength !== undefined) input.minLength = options.minLength;
+  if (options.maxLength !== undefined) input.maxLength = options.maxLength;
+  if (options.pattern !== undefined) input.pattern = options.pattern;
+  if (options.disabled) input.disabled = true;
+  if (options.invalid) {
+    input.setAttribute('aria-invalid', 'true');
+  }
+
+  const variant = options.variant ?? 'default';
+  input.className =
+    `${HUD_INPUT_BASE_CLASS} ${classByVariant[variant]} ${options.className ?? ''}`.trim();
+
+  if (options.onInput) {
+    input.addEventListener('input', (event) => {
+      options.onInput?.(input.value, event);
+    });
+  }
+  if (options.onChange) {
+    input.addEventListener('change', (event) => {
+      options.onChange?.(input.value, event);
+    });
+  }
+  if (options.onKeyDown) {
+    input.addEventListener('keydown', options.onKeyDown);
+  }
+
+  return input;
+}
+
+export type HudInputBaseState = {
+  disabled?: boolean;
+  invalid?: boolean;
+};
+
+export function setHudInputState(
+  input: HTMLInputElement,
+  state: HudInputBaseState
+): void {
+  if (state.disabled !== undefined) {
+    input.disabled = state.disabled;
+  }
+  if (state.invalid !== undefined) {
+    if (state.invalid) {
+      input.setAttribute('aria-invalid', 'true');
+    } else {
+      input.setAttribute('aria-invalid', 'false');
+    }
+  }
+}
+
+// Backward-compatible alias for direct imports from this file.
+export const createHudInput = createHudInputBase;

--- a/src/ui-lib/src/hud/HudSegmentedControl.ts
+++ b/src/ui-lib/src/hud/HudSegmentedControl.ts
@@ -1,0 +1,232 @@
+import {
+  HUD_SEGMENTED_CONTROL_CLASS,
+  HUD_SEGMENTED_ITEM_ACTIVE_CLASS,
+  HUD_SEGMENTED_ITEM_CLASS,
+  HUD_SEGMENTED_ITEM_DISABLED_CLASS,
+  HUD_SEGMENTED_ITEM_INACTIVE_CLASS,
+  HUD_SEGMENTED_ITEM_MD_CLASS,
+  HUD_SEGMENTED_ITEM_SM_CLASS,
+} from './classNames.ts';
+
+export type HudSegmentedControlSize = 'sm' | 'md';
+
+export type HudSegmentedControlOption<T> = {
+  id: string;
+  value: T;
+  label: string;
+  title?: string;
+  disabled?: boolean;
+};
+
+type HudSegmentedControlOptions<T> = {
+  options: HudSegmentedControlOption<T>[];
+  value?: T | null;
+  size?: HudSegmentedControlSize;
+  className?: string;
+  fullWidth?: boolean;
+  disabled?: boolean;
+  ariaLabel?: string;
+  isEqual?: (a: T, b: T) => boolean;
+  onChange?: (value: T) => void;
+};
+
+type Entry<T> = {
+  option: HudSegmentedControlOption<T>;
+  button: HTMLButtonElement;
+};
+
+const classBySize: Record<HudSegmentedControlSize, string> = {
+  sm: HUD_SEGMENTED_ITEM_SM_CLASS,
+  md: HUD_SEGMENTED_ITEM_MD_CLASS,
+};
+
+function toggleClassNames(
+  element: HTMLElement,
+  classNames: string,
+  enabled: boolean
+): void {
+  classNames
+    .split(/\s+/)
+    .filter(Boolean)
+    .forEach((token) => element.classList.toggle(token, enabled));
+}
+
+export class HudSegmentedControl<T> {
+  public readonly element: HTMLDivElement;
+
+  private readonly entries: Entry<T>[] = [];
+  private readonly options: HudSegmentedControlOptions<T>;
+  private readonly isEqual: (a: T, b: T) => boolean;
+  private value: T | null;
+
+  constructor(options: HudSegmentedControlOptions<T>) {
+    this.options = options;
+    this.isEqual = options.isEqual ?? ((a, b) => a === b);
+    this.value = options.value ?? null;
+
+    this.element = document.createElement('div');
+    this.element.className =
+      `${HUD_SEGMENTED_CONTROL_CLASS} ${options.className ?? ''}`.trim();
+    if (options.fullWidth) {
+      this.element.style.display = 'flex';
+      this.element.style.width = '100%';
+    }
+    this.element.setAttribute('role', 'radiogroup');
+    if (options.ariaLabel) {
+      this.element.setAttribute('aria-label', options.ariaLabel);
+    }
+
+    this.render();
+    this.element.addEventListener('keydown', this.handleKeyDown);
+  }
+
+  public getValue(): T | null {
+    return this.value;
+  }
+
+  public setValue(value: T | null): void {
+    this.value = value;
+    this.syncButtons();
+  }
+
+  public setDisabled(disabled: boolean): void {
+    this.options.disabled = disabled;
+    this.syncButtons();
+  }
+
+  public focus(): void {
+    const active = this.getActiveEntry();
+    const firstEnabled = this.entries.find((entry) => !this.isDisabled(entry));
+    (active ?? firstEnabled)?.button.focus();
+  }
+
+  public destroy(): void {
+    this.element.removeEventListener('keydown', this.handleKeyDown);
+  }
+
+  private render(): void {
+    this.element.innerHTML = '';
+    this.entries.length = 0;
+
+    const sizeClass = classBySize[this.options.size ?? 'md'];
+    this.options.options.forEach((option, index) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = `${HUD_SEGMENTED_ITEM_CLASS} ${sizeClass}`;
+      if (this.options.fullWidth) {
+        button.style.flex = '1 1 0';
+        button.style.minWidth = '0';
+      }
+      button.setAttribute('role', 'radio');
+      button.dataset.index = String(index);
+      button.textContent = option.label;
+      if (option.title) {
+        button.title = option.title;
+      }
+      button.addEventListener('click', () => this.handleOptionClick(option));
+
+      this.entries.push({ option, button });
+      this.element.appendChild(button);
+    });
+
+    this.syncButtons();
+  }
+
+  private syncButtons(): void {
+    const activeEntry = this.getActiveEntry();
+    const fallbackFocusable =
+      activeEntry ?? this.entries.find((entry) => !this.isDisabled(entry)) ?? null;
+
+    this.entries.forEach((entry) => {
+      const isActive = this.isActive(entry);
+      const isDisabled = this.isDisabled(entry);
+      entry.button.setAttribute('aria-checked', isActive ? 'true' : 'false');
+      entry.button.disabled = isDisabled;
+      entry.button.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
+      entry.button.tabIndex = fallbackFocusable === entry ? 0 : -1;
+
+      toggleClassNames(entry.button, HUD_SEGMENTED_ITEM_ACTIVE_CLASS, isActive);
+      toggleClassNames(
+        entry.button,
+        HUD_SEGMENTED_ITEM_INACTIVE_CLASS,
+        !isActive && !isDisabled
+      );
+      toggleClassNames(
+        entry.button,
+        HUD_SEGMENTED_ITEM_DISABLED_CLASS,
+        isDisabled
+      );
+    });
+  }
+
+  private handleOptionClick(option: HudSegmentedControlOption<T>): void {
+    const entry = this.entries.find((item) => item.option.id === option.id);
+    if (!entry || this.isDisabled(entry) || this.isActive(entry)) return;
+
+    this.value = option.value;
+    this.syncButtons();
+    this.options.onChange?.(option.value);
+  }
+
+  private readonly handleKeyDown = (event: KeyboardEvent): void => {
+    const current = document.activeElement as HTMLButtonElement | null;
+    if (!current || !this.element.contains(current)) return;
+
+    if (
+      event.key !== 'ArrowRight' &&
+      event.key !== 'ArrowLeft' &&
+      event.key !== 'Home' &&
+      event.key !== 'End'
+    ) {
+      return;
+    }
+    event.preventDefault();
+
+    const enabledEntries = this.entries.filter((entry) => !this.isDisabled(entry));
+    if (enabledEntries.length === 0) return;
+
+    const currentEntry =
+      this.entries.find((entry) => entry.button === current) ?? this.getActiveEntry();
+    if (!currentEntry) return;
+
+    let nextEntry: Entry<T> | null = null;
+    if (event.key === 'Home') {
+      nextEntry = enabledEntries[0];
+    } else if (event.key === 'End') {
+      nextEntry = enabledEntries[enabledEntries.length - 1];
+    } else {
+      const currentEnabledIndex = enabledEntries.indexOf(currentEntry);
+      const delta = event.key === 'ArrowRight' ? 1 : -1;
+      const nextIndex =
+        (currentEnabledIndex + delta + enabledEntries.length) %
+        enabledEntries.length;
+      nextEntry = enabledEntries[nextIndex];
+    }
+
+    if (!nextEntry) return;
+    nextEntry.button.focus();
+    if (!this.isActive(nextEntry)) {
+      this.value = nextEntry.option.value;
+      this.syncButtons();
+      this.options.onChange?.(nextEntry.option.value);
+    }
+  };
+
+  private getActiveEntry(): Entry<T> | null {
+    return this.entries.find((entry) => this.isActive(entry)) ?? null;
+  }
+
+  private isActive(entry: Entry<T>): boolean {
+    return this.value !== null && this.isEqual(entry.option.value, this.value);
+  }
+
+  private isDisabled(entry: Entry<T>): boolean {
+    return Boolean(this.options.disabled || entry.option.disabled);
+  }
+}
+
+export function createHudSegmentedControl<T>(
+  options: HudSegmentedControlOptions<T>
+): HudSegmentedControl<T> {
+  return new HudSegmentedControl(options);
+}

--- a/src/ui-lib/src/hud/HudSurface.ts
+++ b/src/ui-lib/src/hud/HudSurface.ts
@@ -1,0 +1,16 @@
+import {
+  HUD_SURFACE_CLASS,
+  HUD_SURFACE_ELEVATED_CLASS,
+} from './classNames.ts';
+
+type HudSurfaceOptions = {
+  elevated?: boolean;
+  className?: string;
+};
+
+export function createHudSurface(options: HudSurfaceOptions = {}): HTMLDivElement {
+  const surface = document.createElement('div');
+  const baseClass = options.elevated ? HUD_SURFACE_ELEVATED_CLASS : HUD_SURFACE_CLASS;
+  surface.className = `${baseClass} ${options.className ?? ''}`.trim();
+  return surface;
+}

--- a/src/ui-lib/src/hud/HudTextButton.ts
+++ b/src/ui-lib/src/hud/HudTextButton.ts
@@ -1,0 +1,143 @@
+import {
+  HUD_DESTRUCTIVE_BUTTON_CLASS,
+  HUD_TEXT_BUTTON_DANGER_CLASS,
+  HUD_TEXT_BUTTON_SECONDARY_CLASS,
+  HUD_TEXT_BUTTON_TERTIARY_CLASS,
+  HUD_PRIMARY_BUTTON_CLASS,
+} from './classNames.ts';
+import {
+  getHudButtonController,
+  HudButtonBase,
+  type HudButtonElement,
+  type HudButtonState,
+} from './HudButtonBase.ts';
+
+export type HudTextButtonTone =
+  | 'soft'
+  | 'secondary'
+  | 'primary'
+  | 'destructive'
+  | 'text'
+  | 'danger';
+export type HudTextButtonSize = 'sm' | 'md' | 'lg';
+export type HudTextButtonElement = HudButtonElement;
+
+type HudTextButtonOptions = {
+  text?: string;
+  html?: string;
+  className?: string;
+  tone?: HudTextButtonTone;
+  size?: HudTextButtonSize;
+  fullWidth?: boolean;
+  loading?: boolean;
+  loadingText?: string;
+  title?: string;
+  ariaLabel?: string;
+  type?: 'button' | 'submit' | 'reset';
+  disabled?: boolean;
+  onClick?: (event: MouseEvent) => void;
+};
+
+export type HudTextButtonState = HudButtonState;
+
+type HudTextButtonLoadingOptions = {
+  text?: string;
+};
+
+const classByTone: Record<HudTextButtonTone, string> = {
+  soft: HUD_TEXT_BUTTON_SECONDARY_CLASS,
+  secondary: HUD_TEXT_BUTTON_SECONDARY_CLASS,
+  primary: HUD_PRIMARY_BUTTON_CLASS,
+  destructive: HUD_DESTRUCTIVE_BUTTON_CLASS,
+  text: HUD_TEXT_BUTTON_TERTIARY_CLASS,
+  danger: HUD_TEXT_BUTTON_DANGER_CLASS,
+};
+
+const classBySize: Record<HudTextButtonSize, string> = {
+  sm: 'h-8 px-3 text-sm',
+  md: 'h-9 px-3.5 text-sm',
+  lg: 'h-11 px-4 text-sm',
+};
+
+class HudTextButton extends HudButtonBase {
+  constructor(options: HudTextButtonOptions) {
+    const sizeClass = classBySize[options.size ?? 'md'];
+    const widthClass = options.fullWidth ? 'w-full' : '';
+    const className =
+      `${classByTone[options.tone ?? 'soft']} ${sizeClass} ${widthClass} ${options.className ?? ''}`.trim();
+    super({
+      className,
+      type: options.type,
+      title: options.title,
+      ariaLabel: options.ariaLabel,
+      onClick: options.onClick,
+    });
+    const element = this.getElement();
+    if (options.text !== undefined) {
+      element.textContent = options.text;
+    }
+    if (options.html !== undefined) {
+      element.innerHTML = options.html;
+    }
+    this.initializeState({
+      loading: options.loading ?? false,
+      loadingText: options.loadingText,
+      disabled: options.disabled ?? false,
+    });
+  }
+
+  protected renderLoadingContent(loadingText?: string): void {
+    const element = this.getElement();
+    element.innerHTML = '';
+    element.classList.add('inline-flex', 'items-center', 'justify-center', 'gap-2');
+    element.append(this.createSpinner(14));
+    if (loadingText) {
+      const label = document.createElement('span');
+      label.textContent = loadingText;
+      label.className = 'whitespace-nowrap';
+      element.appendChild(label);
+    }
+  }
+
+  protected onLoadingCleared(): void {
+    this.getElement().classList.remove(
+      'inline-flex',
+      'items-center',
+      'justify-center',
+      'gap-2'
+    );
+  }
+}
+
+export function createHudTextButton(
+  options: HudTextButtonOptions
+): HudTextButtonElement {
+  return new HudTextButton(options).getElement();
+}
+
+export function setHudTextButtonState(
+  button: HTMLButtonElement,
+  state: HudTextButtonState
+): void {
+  const controller = getHudButtonController(button);
+  if (controller) {
+    controller.setState(state);
+    return;
+  }
+  if (state.disabled !== undefined) {
+    button.disabled = state.disabled;
+    if (state.disabled) {
+      button.setAttribute('aria-disabled', 'true');
+    } else {
+      button.removeAttribute('aria-disabled');
+    }
+  }
+}
+
+export function setHudTextButtonLoading(
+  button: HTMLButtonElement,
+  loading: boolean,
+  options: HudTextButtonLoadingOptions = {}
+): void {
+  setHudTextButtonState(button, { loading, loadingText: options.text });
+}

--- a/src/ui-lib/src/hud/HudTextInputControl.ts
+++ b/src/ui-lib/src/hud/HudTextInputControl.ts
@@ -1,0 +1,172 @@
+import { createHudIconButton } from './HudIconButton.ts';
+import {
+  createHudInputBase,
+  setHudInputState,
+  type HudInputVariant,
+} from './HudInput.ts';
+import { createIcon, type IconName } from './icons.ts';
+
+export type HudInputKind = 'text' | 'password' | 'email' | 'phone';
+
+export type HudInputOptions = {
+  kind?: HudInputKind;
+  variant?: HudInputVariant;
+  className?: string;
+  inputClassName?: string;
+  type?: string;
+  value?: string;
+  placeholder?: string;
+  name?: string;
+  id?: string;
+  autoFocus?: boolean;
+  autoComplete?: string;
+  required?: boolean;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  disabled?: boolean;
+  invalid?: boolean;
+  onInput?: (value: string, event: Event) => void;
+  onChange?: (value: string, event: Event) => void;
+  onKeyDown?: (event: KeyboardEvent) => void;
+  passwordToggle?: boolean;
+};
+
+type HudInputState = {
+  disabled?: boolean;
+  invalid?: boolean;
+};
+
+export type HudInput = {
+  element: HTMLElement;
+  input: HTMLInputElement;
+  setState: (state: HudInputState) => void;
+  getValue: () => string;
+  setValue: (value: string) => void;
+  focus: () => void;
+};
+
+const kindDefaults: Record<
+  HudInputKind,
+  { type: string; autoComplete?: string; inputMode?: string }
+> = {
+  text: { type: 'text' },
+  password: { type: 'password', autoComplete: 'current-password' },
+  email: { type: 'email', autoComplete: 'email', inputMode: 'email' },
+  phone: { type: 'tel', autoComplete: 'tel', inputMode: 'tel' },
+};
+
+export function createHudInput(options: HudInputOptions = {}): HudInput {
+  const kind = options.kind ?? 'text';
+  const defaults = kindDefaults[kind];
+  const input = createHudInputBase({
+    variant: options.variant ?? 'default',
+    className: options.inputClassName,
+    type: options.type ?? defaults.type,
+    value: options.value,
+    placeholder: options.placeholder,
+    name: options.name,
+    id: options.id,
+    autoFocus: options.autoFocus,
+    autoComplete: options.autoComplete ?? defaults.autoComplete,
+    required: options.required,
+    minLength: options.minLength,
+    maxLength: options.maxLength,
+    pattern: options.pattern,
+    disabled: options.disabled,
+    invalid: options.invalid,
+    onInput: options.onInput,
+    onChange: options.onChange,
+    onKeyDown: options.onKeyDown,
+  });
+
+  if (defaults.inputMode) {
+    input.inputMode = defaults.inputMode as HTMLInputElement['inputMode'];
+  }
+
+  const shouldRenderPasswordToggle =
+    kind === 'password' && options.passwordToggle !== false;
+
+  if (!shouldRenderPasswordToggle) {
+    if (options.className) {
+      input.className = `${input.className} ${options.className}`.trim();
+    }
+    return {
+      element: input,
+      input,
+      setState: (state) => setHudInputState(input, state),
+      getValue: () => input.value,
+      setValue: (value) => {
+        input.value = value;
+      },
+      focus: () => input.focus(),
+    };
+  }
+
+  input.className = `${input.className} pr-11`.trim();
+
+  const wrapper = document.createElement('div');
+  wrapper.className = `relative ${options.className ?? ''}`.trim();
+
+  const toggleButton = createHudIconButton({
+    icon: 'eye',
+    tone: 'text',
+    size: 'sm',
+    iconSize: 14,
+    iconStrokeWidth: 1.8,
+    ariaLabel: 'Show password',
+    type: 'button',
+    className:
+      'absolute right-1 top-1/2 -translate-y-1/2 rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-700',
+  });
+  toggleButton.setAttribute('aria-pressed', 'false');
+  toggleButton.title = 'Show password';
+
+  const setToggleIcon = (iconName: IconName): void => {
+    toggleButton.innerHTML = '';
+    const icon = createIcon(iconName, { size: 14, strokeWidth: 1.8 });
+    icon.setAttribute('aria-hidden', 'true');
+    toggleButton.appendChild(icon);
+  };
+
+  const syncToggleState = (): void => {
+    const isPasswordVisible = input.type === 'text';
+    setToggleIcon(isPasswordVisible ? 'eye-slash' : 'eye');
+    toggleButton.setAttribute(
+      'aria-label',
+      isPasswordVisible ? 'Hide password' : 'Show password'
+    );
+    toggleButton.setAttribute('aria-pressed', isPasswordVisible ? 'true' : 'false');
+    toggleButton.title = isPasswordVisible ? 'Hide password' : 'Show password';
+  };
+
+  toggleButton.addEventListener('click', () => {
+    if (input.disabled) return;
+    input.type = input.type === 'password' ? 'text' : 'password';
+    syncToggleState();
+  });
+
+  wrapper.append(input, toggleButton);
+  syncToggleState();
+
+  return {
+    element: wrapper,
+    input,
+    setState: (state) => {
+      setHudInputState(input, state);
+      if (state.disabled !== undefined) {
+        toggleButton.disabled = state.disabled;
+      }
+    },
+    getValue: () => input.value,
+    setValue: (value) => {
+      input.value = value;
+    },
+    focus: () => input.focus(),
+  };
+}
+
+// Backward-compatible aliases.
+export type HudTextInputKind = HudInputKind;
+export type HudTextInputControl = HudInput;
+export const createHudTextInputControl = createHudInput;

--- a/src/ui-lib/src/hud/classNames.ts
+++ b/src/ui-lib/src/hud/classNames.ts
@@ -1,0 +1,177 @@
+export const HUD_SURFACE_CLASS =
+  'rounded-2xl border border-slate-200/80 bg-white/95 shadow-[0_10px_26px_rgba(15,23,42,0.14)] backdrop-blur-sm';
+
+export const HUD_SURFACE_ELEVATED_CLASS =
+  'rounded-2xl border border-slate-200/80 bg-white/95 shadow-[0_18px_42px_rgba(15,23,42,0.18)] backdrop-blur-sm';
+
+export const HUD_BUTTON_BASE_CLASS =
+  'rounded-full border border-slate-200 bg-white text-slate-700 transition-colors hover:bg-indigo-50 hover:text-indigo-700 focus-visible:ring-indigo-300 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400';
+
+export const HUD_TEXT_BUTTON_SECONDARY_CLASS =
+  'truncate rounded-lg px-3 py-2 text-sm font-semibold text-indigo-600 transition-colors hover:bg-indigo-50 disabled:cursor-not-allowed disabled:bg-transparent disabled:text-slate-400';
+
+export const HUD_TEXT_BUTTON_TERTIARY_CLASS =
+  'truncate rounded-lg px-3 py-2 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-800 disabled:cursor-not-allowed disabled:bg-transparent disabled:text-slate-400';
+
+export const HUD_TEXT_BUTTON_DANGER_CLASS =
+  'truncate rounded-lg px-3 py-2 text-sm font-medium text-rose-600 transition-colors hover:bg-rose-50 hover:text-rose-700 disabled:cursor-not-allowed disabled:bg-transparent disabled:text-slate-400';
+
+export const HUD_ICON_BUTTON_SECONDARY_CLASS =
+  'inline-flex shrink-0 items-center justify-center rounded-lg p-0 text-[15px] font-semibold leading-none text-indigo-500 transition-colors hover:bg-indigo-50 hover:text-indigo-600 disabled:cursor-not-allowed disabled:bg-transparent disabled:text-slate-400';
+
+export const HUD_ICON_BUTTON_TERTIARY_CLASS =
+  'inline-flex shrink-0 items-center justify-center rounded-lg p-0 text-[15px] font-medium leading-none text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-800 disabled:cursor-not-allowed disabled:bg-transparent disabled:text-slate-400';
+
+export const HUD_ICON_BUTTON_DANGER_CLASS =
+  'inline-flex shrink-0 items-center justify-center rounded-lg p-0 text-[15px] font-medium leading-none text-rose-600 transition-colors hover:bg-rose-50 hover:text-rose-700 disabled:cursor-not-allowed disabled:bg-transparent disabled:text-slate-400';
+
+export const HUD_ICON_BUTTON_SIZE_SM_CLASS = 'h-8 w-8';
+export const HUD_ICON_BUTTON_SIZE_MD_CLASS = 'h-9 w-9';
+export const HUD_ICON_BUTTON_SIZE_LG_CLASS = 'h-10 w-10';
+
+export const HUD_PRIMARY_BUTTON_CLASS =
+  'inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-semibold text-white bg-indigo-600 transition-colors hover:border-indigo-600 hover:bg-indigo-700 active:border-indigo-700 active:bg-indigo-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400';
+
+export const HUD_DESTRUCTIVE_BUTTON_CLASS =
+  'inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-semibold text-white bg-rose-600 transition-colors hover:border-rose-600 hover:bg-rose-700 active:border-rose-700 active:bg-rose-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400';
+
+export const HUD_DROPDOWN_CLASS = `${HUD_SURFACE_ELEVATED_CLASS} overflow-hidden`;
+
+export const HUD_DIVIDER_BASE_CLASS = 'border-t';
+export const HUD_DIVIDER_DEFAULT_TONE_CLASS = 'border-slate-200';
+export const HUD_DIVIDER_SOFT_TONE_CLASS = 'border-slate-100';
+export const HUD_DIVIDER_INSET_CLASS = 'mx-2';
+export const HUD_DIVIDER_SPACED_CLASS = 'my-1';
+
+export const HUD_MENU_ITEM_BASE_CLASS =
+  'flex w-full items-center justify-between px-4 py-3 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200 focus-visible:ring-inset';
+
+export const HUD_MENU_ITEM_DEFAULT_CLASS =
+  'font-normal text-slate-600 hover:bg-indigo-50 hover:text-slate-800';
+
+export const HUD_MENU_ITEM_EMPHASIS_CLASS =
+  'font-semibold text-slate-700 hover:bg-indigo-50 hover:text-slate-900';
+
+export const HUD_MENU_ITEM_SELECTED_CLASS =
+  'bg-indigo-50 font-medium text-indigo-700';
+
+export const HUD_MENU_ITEM_ACCENT_CREATE_CLASS =
+  'font-medium text-indigo-600 hover:bg-indigo-50 hover:text-indigo-700';
+
+export const HUD_MENU_ITEM_DANGER_CLASS =
+  'font-medium text-rose-600 hover:bg-rose-50 hover:text-rose-700';
+
+export const HUD_MENU_ITEM_DISABLED_CLASS =
+  'cursor-not-allowed text-slate-400 hover:bg-transparent hover:text-slate-400';
+
+export const HUD_PAGE_EYEBROW_CLASS =
+  'mb-2 inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-400';
+
+export const HUD_PAGE_TITLE_CLASS =
+  'text-[30px] font-semibold leading-none tracking-tight text-slate-900';
+
+export const HUD_FIELD_CLASS = 'mb-4 space-y-1.5';
+export const HUD_FIELD_LABEL_BASE_CLASS = 'block text-[13px] font-medium leading-5';
+export const HUD_FIELD_LABEL_DEFAULT_CLASS = 'text-slate-500';
+export const HUD_FIELD_LABEL_MUTED_CLASS = 'text-slate-400';
+export const HUD_FIELD_LABEL_ERROR_CLASS = 'text-rose-700';
+export const HUD_FIELD_LABEL_DISABLED_CLASS = 'text-slate-400';
+export const HUD_FIELD_REQUIRED_MARK_CLASS = 'ml-1 text-rose-400';
+export const HUD_FIELD_HINT_CLASS = 'text-xs text-slate-500';
+export const HUD_FIELD_ERROR_CLASS = 'text-xs font-medium text-rose-600';
+
+// Backward-compatible alias.
+export const HUD_FIELD_LABEL_CLASS = `${HUD_FIELD_LABEL_BASE_CLASS} ${HUD_FIELD_LABEL_DEFAULT_CLASS}`;
+
+export const HUD_INPUT_BASE_CLASS =
+  'w-full outline-none transition-colors disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400 aria-[invalid=true]:border-rose-300 aria-[invalid=true]:bg-rose-50 aria-[invalid=true]:ring-rose-100';
+
+export const HUD_INPUT_DEFAULT_CLASS =
+  'h-11 rounded-lg border border-slate-200 bg-slate-50 px-3 text-sm text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200';
+
+export const HUD_INPUT_INLINE_CLASS =
+  'h-[34px] rounded-lg border border-indigo-200/70 bg-indigo-50/70 px-3 text-sm font-semibold text-indigo-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.7)] focus:border-indigo-300 focus:bg-white focus:ring-2 focus:ring-indigo-100';
+
+export const HUD_SEGMENTED_CONTROL_CLASS =
+  'inline-flex items-center gap-1 rounded-lg border border-slate-200 bg-white p-1';
+
+export const HUD_SEGMENTED_ITEM_CLASS =
+  'inline-flex items-center justify-center rounded-md px-2.5 text-sm font-medium text-slate-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200 focus-visible:ring-offset-0';
+
+export const HUD_SEGMENTED_ITEM_SM_CLASS = 'h-7 min-w-7 text-xs';
+export const HUD_SEGMENTED_ITEM_MD_CLASS = 'h-8 min-w-8 text-sm';
+
+export const HUD_SEGMENTED_ITEM_ACTIVE_CLASS =
+  'bg-slate-100 text-slate-900';
+
+export const HUD_SEGMENTED_ITEM_INACTIVE_CLASS =
+  'hover:bg-slate-50 hover:text-slate-800';
+
+export const HUD_SEGMENTED_ITEM_DISABLED_CLASS =
+  'cursor-not-allowed text-slate-400 hover:bg-transparent hover:text-slate-400';
+
+// Backward-compatible aliases.
+export const HUD_SOFT_TEXT_BUTTON_CLASS = HUD_TEXT_BUTTON_SECONDARY_CLASS;
+export const HUD_SOFT_ICON_BUTTON_CLASS = HUD_ICON_BUTTON_SECONDARY_CLASS;
+export const HUD_DROPDOWN_ITEM_CLASS = HUD_MENU_ITEM_BASE_CLASS;
+export const HUD_DROPDOWN_ITEM_DEFAULT_CLASS = HUD_MENU_ITEM_DEFAULT_CLASS;
+export const HUD_DROPDOWN_ITEM_ACTIVE_CLASS = HUD_MENU_ITEM_SELECTED_CLASS;
+export const HUD_INLINE_INPUT_CLASS = `${HUD_INPUT_BASE_CLASS} ${HUD_INPUT_INLINE_CLASS}`;
+
+
+// Prefix-free aliases
+export const SURFACE_CLASS = HUD_SURFACE_CLASS;
+export const SURFACE_ELEVATED_CLASS = HUD_SURFACE_ELEVATED_CLASS;
+export const BUTTON_BASE_CLASS = HUD_BUTTON_BASE_CLASS;
+export const TEXT_BUTTON_SECONDARY_CLASS = HUD_TEXT_BUTTON_SECONDARY_CLASS;
+export const TEXT_BUTTON_TERTIARY_CLASS = HUD_TEXT_BUTTON_TERTIARY_CLASS;
+export const TEXT_BUTTON_DANGER_CLASS = HUD_TEXT_BUTTON_DANGER_CLASS;
+export const ICON_BUTTON_SECONDARY_CLASS = HUD_ICON_BUTTON_SECONDARY_CLASS;
+export const ICON_BUTTON_TERTIARY_CLASS = HUD_ICON_BUTTON_TERTIARY_CLASS;
+export const ICON_BUTTON_DANGER_CLASS = HUD_ICON_BUTTON_DANGER_CLASS;
+export const ICON_BUTTON_SIZE_SM_CLASS = HUD_ICON_BUTTON_SIZE_SM_CLASS;
+export const ICON_BUTTON_SIZE_MD_CLASS = HUD_ICON_BUTTON_SIZE_MD_CLASS;
+export const ICON_BUTTON_SIZE_LG_CLASS = HUD_ICON_BUTTON_SIZE_LG_CLASS;
+export const PRIMARY_BUTTON_CLASS = HUD_PRIMARY_BUTTON_CLASS;
+export const DESTRUCTIVE_BUTTON_CLASS = HUD_DESTRUCTIVE_BUTTON_CLASS;
+export const DROPDOWN_CLASS = HUD_DROPDOWN_CLASS;
+export const DIVIDER_BASE_CLASS = HUD_DIVIDER_BASE_CLASS;
+export const DIVIDER_DEFAULT_TONE_CLASS = HUD_DIVIDER_DEFAULT_TONE_CLASS;
+export const DIVIDER_SOFT_TONE_CLASS = HUD_DIVIDER_SOFT_TONE_CLASS;
+export const DIVIDER_INSET_CLASS = HUD_DIVIDER_INSET_CLASS;
+export const DIVIDER_SPACED_CLASS = HUD_DIVIDER_SPACED_CLASS;
+export const MENU_ITEM_BASE_CLASS = HUD_MENU_ITEM_BASE_CLASS;
+export const MENU_ITEM_DEFAULT_CLASS = HUD_MENU_ITEM_DEFAULT_CLASS;
+export const MENU_ITEM_EMPHASIS_CLASS = HUD_MENU_ITEM_EMPHASIS_CLASS;
+export const MENU_ITEM_SELECTED_CLASS = HUD_MENU_ITEM_SELECTED_CLASS;
+export const MENU_ITEM_ACCENT_CREATE_CLASS = HUD_MENU_ITEM_ACCENT_CREATE_CLASS;
+export const MENU_ITEM_DANGER_CLASS = HUD_MENU_ITEM_DANGER_CLASS;
+export const MENU_ITEM_DISABLED_CLASS = HUD_MENU_ITEM_DISABLED_CLASS;
+export const PAGE_EYEBROW_CLASS = HUD_PAGE_EYEBROW_CLASS;
+export const PAGE_TITLE_CLASS = HUD_PAGE_TITLE_CLASS;
+export const FIELD_CLASS = HUD_FIELD_CLASS;
+export const FIELD_LABEL_BASE_CLASS = HUD_FIELD_LABEL_BASE_CLASS;
+export const FIELD_LABEL_DEFAULT_CLASS = HUD_FIELD_LABEL_DEFAULT_CLASS;
+export const FIELD_LABEL_MUTED_CLASS = HUD_FIELD_LABEL_MUTED_CLASS;
+export const FIELD_LABEL_ERROR_CLASS = HUD_FIELD_LABEL_ERROR_CLASS;
+export const FIELD_LABEL_DISABLED_CLASS = HUD_FIELD_LABEL_DISABLED_CLASS;
+export const FIELD_REQUIRED_MARK_CLASS = HUD_FIELD_REQUIRED_MARK_CLASS;
+export const FIELD_HINT_CLASS = HUD_FIELD_HINT_CLASS;
+export const FIELD_ERROR_CLASS = HUD_FIELD_ERROR_CLASS;
+export const FIELD_LABEL_CLASS = HUD_FIELD_LABEL_CLASS;
+export const INPUT_BASE_CLASS = HUD_INPUT_BASE_CLASS;
+export const INPUT_DEFAULT_CLASS = HUD_INPUT_DEFAULT_CLASS;
+export const INPUT_INLINE_CLASS = HUD_INPUT_INLINE_CLASS;
+export const SEGMENTED_CONTROL_CLASS = HUD_SEGMENTED_CONTROL_CLASS;
+export const SEGMENTED_ITEM_CLASS = HUD_SEGMENTED_ITEM_CLASS;
+export const SEGMENTED_ITEM_SM_CLASS = HUD_SEGMENTED_ITEM_SM_CLASS;
+export const SEGMENTED_ITEM_MD_CLASS = HUD_SEGMENTED_ITEM_MD_CLASS;
+export const SEGMENTED_ITEM_ACTIVE_CLASS = HUD_SEGMENTED_ITEM_ACTIVE_CLASS;
+export const SEGMENTED_ITEM_INACTIVE_CLASS = HUD_SEGMENTED_ITEM_INACTIVE_CLASS;
+export const SEGMENTED_ITEM_DISABLED_CLASS = HUD_SEGMENTED_ITEM_DISABLED_CLASS;
+export const SOFT_TEXT_BUTTON_CLASS = HUD_SOFT_TEXT_BUTTON_CLASS;
+export const SOFT_ICON_BUTTON_CLASS = HUD_SOFT_ICON_BUTTON_CLASS;
+export const DROPDOWN_ITEM_CLASS = HUD_DROPDOWN_ITEM_CLASS;
+export const DROPDOWN_ITEM_DEFAULT_CLASS = HUD_DROPDOWN_ITEM_DEFAULT_CLASS;
+export const DROPDOWN_ITEM_ACTIVE_CLASS = HUD_DROPDOWN_ITEM_ACTIVE_CLASS;
+export const INLINE_INPUT_CLASS = HUD_INLINE_INPUT_CLASS;

--- a/src/ui-lib/src/hud/icons.ts
+++ b/src/ui-lib/src/hud/icons.ts
@@ -1,0 +1,342 @@
+export type IconName =
+  | 'edit'
+  | 'copy'
+  | 'add-related'
+  | 'align'
+  | 'map'
+  | 'view-columns'
+  | 'delete'
+  | 'forward'
+  | 'map-pin'
+  | 'pencil'
+  | 'star'
+  | 'square-2-stack'
+  | 'squares-2x2'
+  | 'squares-plus'
+  | 'minus'
+  | 'plus'
+  | 'magnifying-glass'
+  | 'chevron-down'
+  | 'chevron-up'
+  | 'chevron-left'
+  | 'chevron-right'
+  | 'ellipsis-vertical'
+  | 'x-mark'
+  | 'eye'
+  | 'eye-slash'
+  | 'check'
+  | 'trash'
+  | 'arrow-path'
+  | 'arrow-ultum-left'
+  | 'arrow-ultum-right'
+  | 'status-pending'
+  | 'status-defined';
+
+export type IconOptions = {
+  size?: number;
+  strokeWidth?: number;
+};
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+export function createIcon(
+  name: IconName,
+  options: IconOptions = {}
+): SVGSVGElement {
+  const size = options.size ?? 16;
+  const strokeWidth = options.strokeWidth ?? 2;
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('width', size.toString());
+  svg.setAttribute('height', size.toString());
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', strokeWidth.toString());
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+
+  if (name === 'edit') {
+    svg.appendChild(makePath('M3 17.25V21h3.75L17.8 9.95l-3.75-3.75L3 17.25z'));
+    svg.appendChild(
+      makePath(
+        'M20.7 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'copy') {
+    svg.appendChild(makeRect(9, 9, 11, 11, 2));
+    svg.appendChild(makeRect(4, 4, 11, 11, 2));
+    return svg;
+  }
+
+  if (name === 'add-related') {
+    svg.appendChild(makePath('M12 5v14'));
+    svg.appendChild(makePath('M5 12h14'));
+    return svg;
+  }
+
+  if (name === 'align') {
+    svg.appendChild(
+      makePath(
+        'M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'map-pin') {
+    svg.appendChild(makePath('M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z'));
+    svg.appendChild(
+      makePath(
+        'M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'map') {
+    svg.appendChild(
+      makePath(
+        'M9 6.75V15m6-6v8.25m.503 3.498 4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 0 0-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0Z'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'view-columns') {
+    svg.appendChild(
+      makePath(
+        'M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125Z'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'forward') {
+    svg.appendChild(
+      makePath(
+        'M3 8.689c0-.864.933-1.406 1.683-.977l7.108 4.061a1.125 1.125 0 0 1 0 1.954l-7.108 4.061A1.125 1.125 0 0 1 3 16.811V8.69ZM12.75 8.689c0-.864.933-1.406 1.683-.977l7.108 4.061a1.125 1.125 0 0 1 0 1.954l-7.108 4.061a1.125 1.125 0 0 1-1.683-.977V8.69Z'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'pencil') {
+    svg.appendChild(
+      makePath(
+        'm16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'star') {
+    svg.appendChild(
+      makePath(
+        'M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'square-2-stack') {
+    svg.appendChild(
+      makePath(
+        'M16.5 8.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v8.25A2.25 2.25 0 0 0 6 16.5h2.25m8.25-8.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-7.5A2.25 2.25 0 0 1 8.25 18v-1.5m8.25-8.25h-6a2.25 2.25 0 0 0-2.25 2.25v6'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'squares-2x2') {
+    svg.appendChild(
+      makePath(
+        'M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25V18Z'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'squares-plus') {
+    svg.appendChild(
+      makePath(
+        'M13.5 16.875h3.375m0 0h3.375m-3.375 0V13.5m0 3.375v3.375M6 10.5h2.25a2.25 2.25 0 0 0 2.25-2.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v2.25A2.25 2.25 0 0 0 6 10.5Zm0 9.75h2.25A2.25 2.25 0 0 0 10.5 18v-2.25a2.25 2.25 0 0 0-2.25-2.25H6a2.25 2.25 0 0 0-2.25 2.25V18A2.25 2.25 0 0 0 6 20.25Zm9.75-9.75H18a2.25 2.25 0 0 0 2.25-2.25V6A2.25 2.25 0 0 0 18 3.75h-2.25A2.25 2.25 0 0 0 13.5 6v2.25a2.25 2.25 0 0 0 2.25 2.25Z'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'minus') {
+    svg.appendChild(
+      makeFilledPath(
+        'M4.25 12a.75.75 0 0 1 .75-.75h14a.75.75 0 0 1 0 1.5H5a.75.75 0 0 1-.75-.75Z',
+        'evenodd'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'plus') {
+    svg.appendChild(
+      makeFilledPath(
+        'M12 3.75a.75.75 0 0 1 .75.75v6.75h6.75a.75.75 0 0 1 0 1.5h-6.75v6.75a.75.75 0 0 1-1.5 0v-6.75H4.5a.75.75 0 0 1 0-1.5h6.75V4.5a.75.75 0 0 1 .75-.75Z',
+        'evenodd'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'magnifying-glass') {
+    svg.appendChild(
+      makePath(
+        'm21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'chevron-down') {
+    svg.appendChild(makePath('m19.5 8.25-7.5 7.5-7.5-7.5'));
+    return svg;
+  }
+
+  if (name === 'chevron-up') {
+    svg.appendChild(makePath('m4.5 15.75 7.5-7.5 7.5 7.5'));
+    return svg;
+  }
+
+  if (name === 'chevron-left') {
+    svg.appendChild(makePath('M15.75 19.5 8.25 12l7.5-7.5'));
+    return svg;
+  }
+
+  if (name === 'chevron-right') {
+    svg.appendChild(makePath('m8.25 4.5 7.5 7.5-7.5 7.5'));
+    return svg;
+  }
+
+  if (name === 'ellipsis-vertical') {
+    svg.appendChild(
+      makePath(
+        'M12 6.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 12.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 18.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Z'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'trash') {
+    svg.appendChild(
+      makePath(
+        'm14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'arrow-ultum-left') {
+    svg.appendChild(makePath('M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3'));
+    return svg;
+  }
+
+  if (name === 'arrow-ultum-right') {
+    svg.appendChild(makePath('m15 15 6-6m0 0-6-6m6 6H9a6 6 0 0 0 0 12h3'));
+    return svg;
+  }
+
+  if (name === 'x-mark') {
+    svg.appendChild(makePath('M6 18 18 6'));
+    svg.appendChild(makePath('M6 6l12 12'));
+    return svg;
+  }
+
+  if (name === 'eye') {
+    svg.appendChild(
+      makePath(
+        'M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z'
+      )
+    );
+    svg.appendChild(makePath('M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z'));
+    return svg;
+  }
+
+  if (name === 'eye-slash') {
+    svg.appendChild(
+      makePath(
+        'M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'check') {
+    svg.appendChild(makePath('m4.5 12.75 6 6 9-13.5'));
+    return svg;
+  }
+
+  if (name === 'arrow-path') {
+    svg.appendChild(
+      makePath(
+        'M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'status-pending') {
+    svg.appendChild(makePath('M12 4.5h8l-8 9h8'));
+    svg.appendChild(makePath('M4 10.5h7.5l-7.5 9h7.5'));
+    return svg;
+  }
+
+  if (name === 'status-defined') {
+    svg.appendChild(
+      makePath(
+        'M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z'
+      )
+    );
+    return svg;
+  }
+
+  svg.appendChild(makePath('M3 6h18'));
+  svg.appendChild(makePath('M8 6V4h8v2'));
+  svg.appendChild(makeRect(6, 6, 12, 14, 2));
+  return svg;
+}
+
+function makePath(d: string): SVGPathElement {
+  const path = document.createElementNS(SVG_NS, 'path');
+  path.setAttribute('d', d);
+  return path;
+}
+
+function makeFilledPath(
+  d: string,
+  fillRule?: 'evenodd' | 'nonzero'
+): SVGPathElement {
+  const path = makePath(d);
+  path.setAttribute('fill', 'currentColor');
+  path.setAttribute('stroke', 'none');
+  if (fillRule) {
+    path.setAttribute('fill-rule', fillRule);
+    path.setAttribute('clip-rule', fillRule);
+  }
+  return path;
+}
+
+function makeRect(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  rx: number
+): SVGRectElement {
+  const rect = document.createElementNS(SVG_NS, 'rect');
+  rect.setAttribute('x', x.toString());
+  rect.setAttribute('y', y.toString());
+  rect.setAttribute('width', width.toString());
+  rect.setAttribute('height', height.toString());
+  rect.setAttribute('rx', rx.toString());
+  return rect;
+}

--- a/src/ui-lib/src/hud/index.ts
+++ b/src/ui-lib/src/hud/index.ts
@@ -1,0 +1,127 @@
+export { FloatingMenuController } from './FloatingMenuController.ts';
+
+export {
+  HUD_BUTTON_CONTROLLER as BUTTON_CONTROLLER,
+  getHudButtonController as getButtonController,
+  type HudButtonElement as ButtonElement,
+  type HudButtonState as ButtonState,
+  HudButtonBase as ButtonBase,
+} from './HudButtonBase.ts';
+
+export {
+  createHudTextButton as createTextButton,
+  setHudTextButtonLoading as setTextButtonLoading,
+  setHudTextButtonState as setTextButtonState,
+  type HudTextButtonTone as TextButtonTone,
+  type HudTextButtonSize as TextButtonSize,
+  type HudTextButtonElement as TextButtonElement,
+  type HudTextButtonState as TextButtonState,
+} from './HudTextButton.ts';
+
+export {
+  createHudIconButton as createIconButton,
+  setHudIconButtonLoading as setIconButtonLoading,
+  type HudIconButtonTone as IconButtonTone,
+} from './HudIconButton.ts';
+
+export { HudDropdown as Dropdown } from './HudDropdown.ts';
+export { createHudDivider as createDivider } from './HudDivider.ts';
+export { createHudField as createField } from './HudField.ts';
+
+export {
+  createHudFormMessage as createFormMessage,
+  type HudFormMessage as FormMessage,
+  type HudFormMessageTone as FormMessageTone,
+} from './HudFormMessage.ts';
+
+export {
+  createHudDropdownItem as createDropdownItem,
+  type HudDropdownItemTone as DropdownItemTone,
+  type HudMenuItemVariant as MenuItemVariant,
+} from './HudDropdownItem.ts';
+
+export {
+  createHudInputBase as createInputBase,
+  setHudInputState as setInputState,
+  type HudInputBaseOptions as InputBaseOptions,
+  type HudInputBaseState as InputBaseState,
+  type HudInputVariant as InputVariant,
+} from './HudInput.ts';
+
+export {
+  createHudInput as createInput,
+  type HudInput as Input,
+  type HudInputKind as InputKind,
+  createHudTextInputControl as createTextInputControl,
+  type HudTextInputControl as TextInputControl,
+  type HudTextInputKind as TextInputKind,
+} from './HudTextInputControl.ts';
+
+export {
+  createHudSegmentedControl as createSegmentedControl,
+  HudSegmentedControl as SegmentedControl,
+  type HudSegmentedControlOption as SegmentedControlOption,
+  type HudSegmentedControlSize as SegmentedControlSize,
+} from './HudSegmentedControl.ts';
+
+export { createHudSurface as createSurface } from './HudSurface.ts';
+
+export * from './classNames.ts';
+
+// Compatibility exports for incremental migration
+export {
+  createHudIconButton,
+  setHudIconButtonLoading,
+  type HudIconButtonTone,
+} from './HudIconButton.ts';
+export {
+  HUD_BUTTON_CONTROLLER,
+  getHudButtonController,
+  type HudButtonElement,
+  type HudButtonState,
+  HudButtonBase,
+} from './HudButtonBase.ts';
+export {
+  createHudTextButton,
+  setHudTextButtonLoading,
+  setHudTextButtonState,
+  type HudTextButtonTone,
+  type HudTextButtonSize,
+  type HudTextButtonElement,
+  type HudTextButtonState,
+} from './HudTextButton.ts';
+export { HudDropdown } from './HudDropdown.ts';
+export { createHudDivider } from './HudDivider.ts';
+export { createHudField } from './HudField.ts';
+export {
+  createHudFormMessage,
+  type HudFormMessage,
+  type HudFormMessageTone,
+} from './HudFormMessage.ts';
+export {
+  createHudDropdownItem,
+  type HudDropdownItemTone,
+  type HudMenuItemVariant,
+} from './HudDropdownItem.ts';
+export {
+  createHudInputBase,
+  setHudInputState,
+  type HudInputBaseOptions,
+  type HudInputBaseState,
+  type HudInputVariant,
+} from './HudInput.ts';
+export {
+  createHudInput,
+  type HudInput,
+  type HudInputKind,
+  createHudTextInputControl,
+  type HudTextInputControl,
+  type HudTextInputKind,
+} from './HudTextInputControl.ts';
+export {
+  createHudSegmentedControl,
+  HudSegmentedControl,
+  type HudSegmentedControlOption,
+  type HudSegmentedControlSize,
+} from './HudSegmentedControl.ts';
+export { createHudSurface } from './HudSurface.ts';

--- a/src/ui-lib/src/index.ts
+++ b/src/ui-lib/src/index.ts
@@ -7,3 +7,5 @@ export { ComponentFactory } from './core/ComponentFactory.ts';
 export { UIManager } from './core/UIManager.ts';
 export { ThemeManager } from './core/Theme.ts';
 export { ToastProvider } from './components/ToastProvider.ts';
+
+export * from './hud/index.ts';


### PR DESCRIPTION
### Motivation

- Consolidate reusable HUD/UI primitives that lived under `features/canvas/ui` into the shared `ui-lib` so they can be reused by other features and reduce API duplication. 
- Provide a stable, prefix-free API surface while keeping backward-compatible `Hud*` exports during an incremental migration. 

### Description

- Added a full `hud` toolkit under `src/ui-lib/src/hud/` including `FloatingMenuController`, `HudButtonBase`, `HudTextButton`, `HudIconButton`, `HudInput`/`HudTextInputControl`, `HudField`, `HudFormMessage`, `HudDropdown`, `HudDropdownItem`, `HudSegmentedControl`, `HudDivider`, `HudSurface`, `icons.ts` and `classNames.ts` constants. 
- Exported a consolidated, prefix-free API from `src/ui-lib/src/hud/index.ts` and re-exported the legacy `Hud*` symbols for compatibility. 
- Updated `src/ui-lib/src/index.ts` to export the new `hud` module via `export * from './hud/index.ts'`. 
- Updated `src/features/canvas/ui/primitives/index.ts` to re-export implementations from the new `ui-lib` `hud` index and added prefix-free aliases for new code, and added a migration analysis document at `docs/CANVAS-UI-TO-UI-LIB-ANALYSIS.md`. 

### Testing

- Ran the TypeScript compile/typecheck (`tsc`) to validate the new module and exports, which completed successfully. 
- Executed the existing test suite (`npm test`), and all tests passed against the updated exports.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e26d82008331861d8cf251f8ea3d)