### PR TITLE
Fix status selector step button order

### DIFF
--- a/src/features/canvas/ui/components/StatusSelector.ts
+++ b/src/features/canvas/ui/components/StatusSelector.ts
@@ -39,6 +39,13 @@ const STATUS_STEP_TONE_CLASS: Record<ElementStatus, string> = {
 const STATUS_STEP_MIXED_TONE_CLASS =
   'bg-slate-100/60 text-slate-600 hover:bg-slate-200/70 hover:text-slate-700';
 
+const STATUS_STEP_ORDER: readonly ElementStatus[] = [
+  ElementStatus.Defined,
+  ElementStatus.Pending,
+  ElementStatus.InProgress,
+  ElementStatus.Done,
+];
+
 type StatusSelectorOptions = {
   onStatusChange: (status: ElementStatus) => void;
 };
@@ -287,9 +294,9 @@ export class StatusSelector {
       this.setTriggerStatusBackground(this.currentStatus);
       this.setStepButtonsStatusTone(this.currentStatus);
 
-      const index = STATUS_ORDER.indexOf(this.currentStatus);
+      const index = STATUS_STEP_ORDER.indexOf(this.currentStatus);
       this.prevBtn.disabled = index <= 0;
-      this.nextBtn.disabled = index >= STATUS_ORDER.length - 1;
+      this.nextBtn.disabled = index >= STATUS_STEP_ORDER.length - 1;
     }
 
     const triggerText =
@@ -306,11 +313,11 @@ export class StatusSelector {
 
   private stepStatus(direction: -1 | 1): void {
     if (this.currentStatus === null) return;
-    const currentIndex = STATUS_ORDER.indexOf(this.currentStatus);
+    const currentIndex = STATUS_STEP_ORDER.indexOf(this.currentStatus);
     if (currentIndex === -1) return;
     const nextIndex = currentIndex + direction;
-    if (nextIndex < 0 || nextIndex >= STATUS_ORDER.length) return;
-    const nextStatus = STATUS_ORDER[nextIndex];
+    if (nextIndex < 0 || nextIndex >= STATUS_STEP_ORDER.length) return;
+    const nextStatus = STATUS_STEP_ORDER[nextIndex];
     this.currentStatus = nextStatus;
     this.syncUi();
     this.onStatusChange(nextStatus);


### PR DESCRIPTION
### Motivation
- The left/right step buttons in the status selector used the dropdown display order (`STATUS_ORDER`) for stepping, which became reversed after the dropdown order was changed; arrow navigation should follow a natural progression, not the visual dropdown order.

### Description
- Added a separate logical progression array `STATUS_STEP_ORDER` with order `Defined -> Pending -> In Progress -> Done` in `src/features/canvas/ui/components/StatusSelector.ts`.
- Updated previous/next disabled-state calculation to use `STATUS_STEP_ORDER` instead of `STATUS_ORDER`.
- Updated `stepStatus` to compute next status from `STATUS_STEP_ORDER` so arrow buttons move through statuses in the intended direction while the dropdown display (`STATUS_ORDER`) remains unchanged.

### Testing
- Ran `npm run test` and all tests passed: 11 test files, 58 tests (`vitest` run succeeded).
- Attempted `npm run test -- --runInBand` which failed because `vitest` does not recognize the `--runInBand` option (expected CLI limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a466640a7483318e5d078e2d729065)