### PR TITLE
Reset change history when switching canvases

### DIFF
--- a/src/features/canvas/CanvasApp.ts
+++ b/src/features/canvas/CanvasApp.ts
@@ -297,6 +297,8 @@ export class CanvasApp {
     }>;
     const id = customEvent.detail?.id;
     if (!id) return;
+    const activeCanvasId = this.canvasDataService.getActiveCanvasId();
+    const isCanvasSwitched = activeCanvasId !== id;
     if (!this.authService.isLoggedIn()) {
       authFlowService.requestLogin('canvas-access');
       return;
@@ -304,6 +306,9 @@ export class CanvasApp {
     const name = customEvent.detail?.name || 'New canvas';
     this.canvasDataService.loadCanvasDetails(id).subscribe({
       next: (canvas) => {
+        if (isCanvasSwitched) {
+          historyService.reset();
+        }
         this.setCanvasTitle(canvas.name);
         this.restoreCanvasViewState(canvas.id).finally(() => {
           this.loadActiveCanvasElements();
@@ -313,6 +318,9 @@ export class CanvasApp {
       error: (err) => {
         console.error('Failed to load canvas details', err);
         this.canvasDataService.setActiveCanvas({ id, name });
+        if (isCanvasSwitched) {
+          historyService.reset();
+        }
         this.setCanvasTitle(name);
         this.restoreCanvasViewState(id).finally(() => {
           this.loadActiveCanvasElements();
@@ -329,6 +337,7 @@ export class CanvasApp {
     }
     this.canvasDataService.createCanvas('New canvas').subscribe({
       next: (canvas) => {
+        historyService.reset();
         this.setCanvasTitle(canvas.name);
         this.restoreCanvasViewState(canvas.id).finally(() => {
           this.refreshCanvasList(canvas.id);
@@ -623,6 +632,7 @@ export class CanvasApp {
       this.canvasManager.setLoadPhase('idle');
       this.scene.clear();
       this.canvasManager.clearLoadingPlaceholders();
+      historyService.reset();
       this.setCanvasTitle('New canvas');
       this.refreshCanvasList(null);
       return;
@@ -632,6 +642,7 @@ export class CanvasApp {
     // replace bootstrap + elements + relations chain with single snapshot hydration.
     this.canvasDataService.bootstrapCanvas().subscribe({
       next: ({ canvases, activeCanvas }) => {
+        historyService.reset();
         this.setCanvasTitle(activeCanvas.name);
         this.setCanvasListCache(canvases);
         this.emitCanvasList(
@@ -1107,6 +1118,7 @@ export class CanvasApp {
         const createdCanvas = await firstValueFrom(
           this.canvasDataService.createCanvas('New canvas')
         );
+        historyService.reset();
         this.setCanvasTitle(createdCanvas.name);
         await this.restoreCanvasViewState(createdCanvas.id);
         this.refreshCanvasList(createdCanvas.id);
@@ -1129,6 +1141,7 @@ export class CanvasApp {
         this.setCanvasTitle(nextCanvas.name);
       }
 
+      historyService.reset();
       await this.restoreCanvasViewState(nextCanvas.id);
       this.refreshCanvasList(nextCanvas.id);
       this.loadActiveCanvasElements();

--- a/src/features/canvas/core/services/HistoryService.test.ts
+++ b/src/features/canvas/core/services/HistoryService.test.ts
@@ -92,4 +92,20 @@ describe('HistoryService save-state tracking', () => {
 
     expect(service.hasUnsavedChanges()).toBe(false);
   });
+
+  it('clears undo/redo stacks and saved state on reset', () => {
+    const service = new HistoryService();
+    service.execute(new TestCommand(true));
+    service.undo();
+
+    expect(service.canRedo()).toBe(true);
+    expect(service.hasUnsavedChanges()).toBe(true);
+
+    service.reset();
+
+    expect(service.canUndo()).toBe(false);
+    expect(service.canRedo()).toBe(false);
+    expect(service.hasUnsavedChanges()).toBe(false);
+    expect(service.getStateToken()).toEqual({ branchId: 0, index: 0 });
+  });
 });

--- a/src/features/canvas/core/services/HistoryService.ts
+++ b/src/features/canvas/core/services/HistoryService.ts
@@ -84,6 +84,15 @@ export class HistoryService {
     );
   }
 
+  public reset(): void {
+    this.undoStack = [];
+    this.redoStack = [];
+    this.branchId = 0;
+    this.savedBranchId = 0;
+    this.savedIndex = 0;
+    this.changes.next();
+  }
+
   private getTrackedUndoCount(): number {
     let count = 0;
     for (const command of this.undoStack) {


### PR DESCRIPTION
### Motivation

- When the user switches to a different canvas, the previous canvas' undo/redo/unsaved-change state must not carry over because those changes are not relevant for the new canvas.  

### Description

- Add `reset()` to `HistoryService` to clear `undoStack`, `redoStack`, branch tracking and saved-state, and notify subscribers via `changes.next()`.  
- Reset the history when the active canvas context changes by invoking `historyService.reset()` in `CanvasApp` when selecting another canvas (only if the `id` actually changed), when creating a new canvas, during bootstrap/login transitions to the not-logged-in path, and after switching to another canvas following a delete.  
- Add a unit test in `HistoryService.test.ts` that verifies `reset()` clears undo/redo stacks, clears unsaved state, and resets the state token to `{ branchId: 0, index: 0 }`.

### Testing

- Attempted to run the unit tests with `npm test -- src/features/canvas/core/services/HistoryService.test.ts`, but the run failed because `vitest` was not available in the environment (error: `vitest: not found`).  
- Tried `npx vitest run src/features/canvas/core/services/HistoryService.test.ts`, but that attempt was blocked by the environment's npm registry access (`403 Forbidden`).  
- `npm ci` was invoked to install dependencies but test execution remains blocked in this environment; the new test is present and should pass when run in a normal dev environment with `vitest` available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46afc9a7883318cdc265d4314f2bf)