### PR TITLE
Restore story→task containment when pasting copied story bundles

### DIFF
--- a/src/features/canvas/core/services/ClipboardService.test.ts
+++ b/src/features/canvas/core/services/ClipboardService.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { ClipboardService } from './ClipboardService.ts';
+import { Scene } from '../scene/Scene.ts';
+import { StoryElement } from '../../elements/StoryElement.ts';
+import { TaskElement } from '../../elements/TaskElement.ts';
+
+describe('ClipboardService', () => {
+  it('keeps copied task inside copied story after paste', () => {
+    const clipboard = new ClipboardService();
+    const scene = new Scene();
+
+    const story = new StoryElement({
+      x: 100,
+      y: 100,
+      width: 500,
+      height: 300,
+    });
+    const taskInStory = new TaskElement({ x: 160, y: 180 });
+    story.addTask(taskInStory);
+
+    clipboard.copy([story, taskInStory]);
+
+    const pasted = clipboard.paste(scene, { x: 900, y: 700 });
+
+    const pastedStory = pasted.find(
+      (element): element is StoryElement => element instanceof StoryElement
+    );
+    const pastedTask = pasted.find(
+      (element): element is TaskElement => element instanceof TaskElement
+    );
+
+    expect(pastedStory).toBeDefined();
+    expect(pastedTask).toBeDefined();
+    expect(pastedStory?.tasks.map((task) => task.id)).toContain(pastedTask?.id);
+  });
+
+  it('does not attach pasted tasks that are outside of pasted story', () => {
+    const clipboard = new ClipboardService();
+    const scene = new Scene();
+
+    const story = new StoryElement({ x: 100, y: 100, width: 300, height: 220 });
+    const taskOutside = new TaskElement({ x: 480, y: 360 });
+
+    clipboard.copy([story, taskOutside]);
+
+    const pasted = clipboard.paste(scene, { x: 900, y: 700 });
+
+    const pastedStory = pasted.find(
+      (element): element is StoryElement => element instanceof StoryElement
+    );
+
+    expect(pastedStory).toBeDefined();
+    expect(pastedStory?.tasks).toHaveLength(0);
+  });
+});

--- a/src/features/canvas/core/services/ClipboardService.ts
+++ b/src/features/canvas/core/services/ClipboardService.ts
@@ -1,7 +1,8 @@
 import { Scene } from '../scene/Scene.ts';
 import { PlanningElement } from '../../elements/PlanningElement.ts';
+import { StoryElement } from '../../elements/StoryElement.ts';
+import { TaskElement } from '../../elements/TaskElement.ts';
 import { v4 as uuidv4 } from 'uuid';
-import { getBoundingBox } from '../utils/geometryUtils.ts';
 
 /**
  * Clipboard service stores copies of PlanningElement for paste operations.
@@ -64,7 +65,34 @@ export class ClipboardService {
       scene.addElement(newClone);
       return newClone;
     });
+
+    this.restoreStoryTaskContainment(clones);
+
     return clones;
+  }
+
+  private restoreStoryTaskContainment(elements: PlanningElement[]): void {
+    const stories = elements.filter(
+      (element): element is StoryElement => element instanceof StoryElement
+    );
+    const tasks = elements.filter(
+      (element): element is TaskElement => element instanceof TaskElement
+    );
+
+    if (stories.length === 0 || tasks.length === 0) {
+      return;
+    }
+
+    stories.forEach((story) => {
+      story.tasks = [];
+      tasks.forEach((task) => {
+        const anchorX = task.x + TaskElement.width / 2;
+        const anchorY = task.y + TaskElement.height / 2;
+        if (story.contains(anchorX, anchorY)) {
+          story.addTask(task);
+        }
+      });
+    });
   }
 
   public clear(): void {


### PR DESCRIPTION
### Motivation
- Fix a bug where copying a `StoryElement` together with its `TaskElement`s produced pasted tasks that were not attached to the pasted story despite having coordinates inside it.
- Ensure that when a user pastes a bundle of story+tasks the story's `tasks` array is rebuilt to reflect containment by coordinates.

### Description
- Added logic to `ClipboardService.paste` to call a new private method `restoreStoryTaskContainment` after cloned elements are added to the `Scene`.
- Implemented `restoreStoryTaskContainment` which filters pasted `StoryElement`s and `TaskElement`s and attaches tasks to stories when the task anchor (center) is inside the story bounds.
- Removed an unused `getBoundingBox` import from `src/features/canvas/core/services/ClipboardService.ts` and added imports for `StoryElement` and `TaskElement`.
- Added unit tests at `src/features/canvas/core/services/ClipboardService.test.ts` that cover: a task copied with a story remains attached after paste, and a task outside the story does not get attached.

### Testing
- Added unit tests in `src/features/canvas/core/services/ClipboardService.test.ts` but they were not executed successfully in this environment because the test runner is not available.
- Attempted to run `npm test -- ClipboardService.test.ts StoryLayoutService.test.ts` and it failed with `sh: 1: vitest: not found` so automated tests could not be run here.
- Files changed: `src/features/canvas/core/services/ClipboardService.ts` and `src/features/canvas/core/services/ClipboardService.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a471386b5c8331be4b3e778bd4d9e5)