### PR TITLE
Add pinned favorites section to canvas selector

### DIFF
--- a/src/features/canvas/ui/components/CanvasBoardSelector.ts
+++ b/src/features/canvas/ui/components/CanvasBoardSelector.ts
@@ -326,15 +326,19 @@ export class CanvasBoardSelector {
       return;
     }
 
-    const sortedCanvases = this.canvases
-      .map((canvas, index) => ({ canvas, index }))
-      .sort((left, right) => {
-        const favoriteOrder =
-          Number(right.canvas.isFavorite) - Number(left.canvas.isFavorite);
-        if (favoriteOrder !== 0) return favoriteOrder;
-        return left.index - right.index;
-      })
-      .map((entry) => entry.canvas);
+    const pinnedCanvases = this.canvases.filter((canvas) => canvas.isFavorite);
+
+    if (pinnedCanvases.length > 0) {
+      const pinnedRows = pinnedCanvases.map((canvas) =>
+        this.createCanvasRow(canvas, { noGroupIndent: true })
+      );
+      const pinnedGroup = new MenuItemGroup({
+        id: '__pinned__',
+        label: 'Pinned',
+        items: pinnedRows,
+      });
+      this.listWrap.appendChild(pinnedGroup.getElement());
+    }
 
     const groupedCanvases = new Map<
       string,
@@ -342,7 +346,7 @@ export class CanvasBoardSelector {
     >();
     const ungroupedCanvases: CanvasItem[] = [];
 
-    sortedCanvases.forEach((canvas) => {
+    this.canvases.forEach((canvas) => {
       if (!canvas.group) {
         ungroupedCanvases.push(canvas);
         return;
@@ -387,9 +391,13 @@ export class CanvasBoardSelector {
     });
   }
 
-  private createCanvasRow(canvas: CanvasItem): HTMLDivElement {
+  private createCanvasRow(
+    canvas: CanvasItem,
+    options?: { noGroupIndent?: boolean }
+  ): HTMLDivElement {
     const isActive = canvas.id === this.activeCanvasId;
     const isUnavailable = canvas.id.startsWith('missing-id-');
+    const shouldIndentGroup = canvas.group && options?.noGroupIndent !== true;
     return createSplitDropdownItem({
       label: canvas.name,
       variant: isActive ? 'selected' : 'default',
@@ -398,7 +406,7 @@ export class CanvasBoardSelector {
       leading: this.createCanvasLeadingIcon(isActive),
       hideSelectedTrailing: this.hideSelectedCheckInCanvasItems,
       trailing: isActive ? this.createCheckIcon() : null,
-      className: `min-w-0 ${canvas.group ? 'pl-6' : ''}`,
+      className: `min-w-0 ${shouldIndentGroup ? 'pl-6' : ''}`,
       disabled: isUnavailable,
       secondaryIcon: canvas.isFavorite ? 'star-solid' : 'star',
       secondaryLabel: canvas.isFavorite


### PR DESCRIPTION
### Motivation
- Provide quick access to favorite (starred) canvases by surfacing them at the top of the selector without removing them from their original groups.

### Description
- Add a new `Pinned` `MenuItemGroup` rendered at the top of the dropdown that contains duplicated rows for all `isFavorite` canvases.
- Introduce an optional `noGroupIndent` flag on `createCanvasRow` so pinned rows are visually aligned and do not get group indentation.
- Stop using the previous global “favorites-first” sort for the main list and keep original group/ungrouped rendering so canvases still appear in their groups below the pinned block.
- Pinned rows reuse existing row behavior (select, favorite toggle, actions) and are created with `id: '__pinned__'` for the group header.

### Testing
- Ran unit tests with `npm run test` (Vitest) and all tests passed.
- Verified production build with `npm run build` (Vite) and build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5686fbe648331918552b6372c18c3)