### PR TITLE
Add read-only Element Details modal, ElementDetailsService, relationship resolvers, and view event

### DIFF
--- a/docs/ELEMENT-DETAILS-UX-IMPLEMENTATION-PLAN.md
+++ b/docs/ELEMENT-DETAILS-UX-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,287 @@
+# Canvas Element Details — UX/Architecture Implementation Plan
+
+## Request summary
+
+Implement richer **Element Details** behavior in canvas:
+
+1. In Edit modal (or in a dedicated read-only `View Element/Element Details` modal) add a right-side column with related stories for the selected goal/task.
+2. Add one more right-side column with tasks for the currently selected story.
+3. For Story view, show story tasks in the same pattern.
+
+## Current architecture (what we should reuse)
+
+- `EditElementModal` is currently a **single-column form modal** that edits title/description/status/priority (+ due date for task, scale for goal). It is opened from `UIManager` via `editElement$`.  
+- Related entities loading logic already exists in `RelatedItemsPicker` and uses `StoriesApiService` / `GoalsApiService` with backend references (`id`/`uuid`) and missing-item filtering.
+- `StoryElement` already stores local `tasks: TaskElement[]`, which is useful for immediate rendering, but this list is incomplete when only part of the graph is loaded — so API-backed hydration is still needed for reliable details view.
+
+## UX recommendation (senior-level)
+
+### 1) Split “Edit” and “Details” concerns
+
+**Recommended:** keep `EditElementModal` lightweight and create a new `ElementDetailsModal` (or `ViewElementModal`) for exploration/navigation.
+
+Why:
+- Editing form and relationship browsing are different intents.
+- 3-column content in edit flow increases cognitive load and accidental edits.
+- Details modal can be safely reused from context menu, double-click, and future deep-linking.
+
+**Fallback:** if product wants one entry point now, keep tabs in a unified modal:
+- `Edit` tab (existing form)
+- `Details` tab (new columns)
+
+### 2) 3-column interaction model
+
+Desktop layout:
+- **Column A (primary):** selected element summary (title, type, status, description).
+- **Column B (middle):** related stories list.
+- **Column C (right):** tasks of selected story.
+
+Behavior:
+- First story auto-selected when list is non-empty.
+- Empty states must be explicit:
+  - “No related stories”
+  - “Select a story to see tasks” / “No tasks in this story”
+- Keep row density compact (32–36px rows), with status dot + title.
+- Preserve keyboard support (↑/↓ for lists, Enter to focus/open).
+
+For **Story Details**:
+- Reuse Columns A + C only (or keep B hidden and treat selected story as context).
+- Tasks list should match same component as Column C to avoid visual divergence.
+
+### 3) Microinteractions
+
+- Skeleton loaders per column (not full-modal blocking).
+- Sticky column headers with counts: `Stories (12)`, `Tasks (34)`.
+- “Open on canvas” action for list item to pan/zoom + highlight element if it exists on scene.
+- “Add to canvas” CTA for backend items missing on scene (reuse existing add services).
+
+## Technical implementation in current codebase
+
+## A. New UI component structure
+
+Create:
+- `src/features/canvas/ui/components/ElementDetailsModal.ts`
+- `src/features/canvas/ui/components/ElementDetailsColumns.ts` (optional split)
+- `src/features/canvas/ui/components/RelatedStoryList.ts`
+- `src/features/canvas/ui/components/RelatedTaskList.ts`
+
+Reuse modal shell utilities from `ui-lib` (`createModalShell`, action rows).
+
+## B. Data orchestration service (important for dependency separation)
+
+Create dedicated service:
+- `src/features/canvas/core/services/ElementDetailsService.ts`
+
+Responsibilities:
+- Resolve selected element backend reference (`id/uuid`).
+- Load related stories for Goal/Task context.
+- Load tasks for selected story.
+- Normalize to view models:
+  - `StoryListItemVM`
+  - `TaskListItemVM`
+- Cache requests for modal session (Map by ref key) to avoid duplicate roundtrips.
+
+Why service layer:
+- Keeps modal components presentational.
+- Avoids duplicating logic currently embedded in `RelatedItemsPicker`.
+- Easier to unit test (API mapping + fallback behavior).
+
+## C. Shared relationship resolver extraction
+
+`RelatedItemsPicker` already contains useful methods (`collectStoriesFromGoalTasks`, backend ref keys, filtering). Extract shared pure helpers into:
+- `src/features/canvas/core/services/relationshipResolvers.ts`
+
+Then consume in both picker and details modal.
+
+## D. Modal entry points
+
+In `UIManager`:
+- Keep current `editElement$ -> EditElementModal` behavior.
+- Add a new trigger (e.g. `viewElementDetails$` or custom DOM event) to open `ElementDetailsModal`.
+
+Context menu / selection actions:
+- Add “View details” action for Goal/Story/Task.
+- Optional: from Edit modal add secondary button `Show details`.
+
+## E. State model for cascading selection
+
+Within Details modal state:
+- `selectedElement`
+- `stories: StoryListItemVM[]`
+- `activeStoryId: string | number | null`
+- `tasks: TaskListItemVM[]`
+- `loadingStories`, `loadingTasks`, `errorStories`, `errorTasks`
+
+Rules:
+- On element change -> load stories -> auto-select first -> load tasks.
+- On manual story click -> load tasks for clicked story.
+- Keep previous tasks visible until new tasks arrive (with subtle loading state), avoiding flicker.
+
+## F. Performance and resilience
+
+- Debounce rapid reselection (100–150ms) before API call.
+- Cancel stale in-flight requests via RxJS `switchMap`.
+- Show partial content if one column fails; do not fail whole modal.
+- Respect offline/error fallback text and retry action per column.
+
+## G. Accessibility
+
+- Columns as ARIA regions with clear labels.
+- List rows are buttons (`role="option"` inside `listbox` or semantic `<button>` list).
+- Visible focus ring and keyboard navigation parity.
+- Maintain ESC-close and modal focus trap behavior.
+
+## Suggested delivery phases
+
+### Phase 1 (low risk, quick value)
+- Create `ElementDetailsModal` read-only.
+- Goal/Task: stories + selected story tasks.
+- Story: direct tasks list.
+
+### Phase 2
+- Add “Open on canvas” / “Add to canvas” actions.
+- Add session cache + stale request cancellation.
+
+### Phase 3
+- Optional merge with Edit via tabs if product insists on single modal entry point.
+
+## Acceptance criteria
+
+- Opening Details for Goal/Task shows related stories in middle column.
+- Selecting story updates right column with its tasks.
+- Opening Details for Story shows its tasks with identical list component.
+- Empty/loading/error states are distinct and non-blocking.
+- Keyboard-only flow works across both lists.
+
+## Risks and mitigations
+
+- **Risk:** duplicated business rules between picker and details modal.  
+  **Mitigation:** extract relationship resolver helpers once.
+- **Risk:** modal becomes overloaded if merged with Edit.  
+  **Mitigation:** keep separate modal or enforce tab separation.
+- **Risk:** inconsistent scene-vs-backend entity presence.  
+  **Mitigation:** explicit badges (“On canvas” / “Not on canvas”) and clear CTA.
+
+## Practical implementation walkthrough in existing code
+
+This section explains exactly **how I would implement it in the current canvas architecture**.
+
+### 1) Keep existing `EditElementModal` as-is, add separate Details modal
+
+Why in this codebase:
+- `EditElementModal` already contains a focused edit form lifecycle (unsaved guard, save patch emission, keyboard enter/escape behavior).
+- Expanding it into 3 columns will couple API-loading/orchestration into form code and make maintainability worse.
+
+Implementation:
+- New file: `src/features/canvas/ui/components/ElementDetailsModal.ts`.
+- Reuse the same modal shell primitives (`createModalShell`) for visual consistency.
+- Keep `EditElementModal` untouched except optional “Show details” secondary action.
+
+### 2) Add Details trigger alongside existing edit trigger in `UIManager`
+
+Current behavior:
+- `UIManager` subscribes to `editElement$` and opens `new EditElementModal(el, this.scene).show()`.
+
+Implementation:
+- Add new event bus stream (example: `viewElementDetails$`) in `core/eventBus.ts`.
+- Subscribe in `UIManager` similarly to edit flow and open `ElementDetailsModal`.
+- Add invocation point in context menu / selection action menu: “View details”.
+
+Result:
+- No regression in existing edit flow.
+- Details opens from the same UI interaction patterns users already know.
+
+### 3) Extract relationship helpers from `RelatedItemsPicker`
+
+Current problem:
+- `RelatedItemsPicker` owns useful relationship logic but it is embedded as private methods and tightly coupled to picker UI state.
+
+Implementation:
+- Create `src/features/canvas/core/services/relationshipResolvers.ts` with pure helper functions:
+  - get backend ref keys for story/task/goal,
+  - collect stories from goal tasks,
+  - merge/de-duplicate story arrays,
+  - filter out already-on-canvas entities.
+- Replace duplicated private picker logic with imported helpers.
+- Reuse same helpers in `ElementDetailsService`.
+
+Result:
+- One source of truth for relation rules.
+- Lower bug risk when relation policy changes.
+
+### 4) Add `ElementDetailsService` for data flow orchestration
+
+New service:
+- `src/features/canvas/core/services/ElementDetailsService.ts`.
+
+Dependencies:
+- `StoriesApiService`, `GoalsApiService` (same as picker).
+- Optional `TasksApiService` only if needed for enriched task details.
+
+Public API (example):
+- `loadStoriesForElement(element: TaskElement | StoryElement | GoalElement): Observable<StoryListItemVM[]>`
+- `loadTasksForStory(storyRef: { id?: number; uuid?: string }): Observable<TaskListItemVM[]>`
+
+Behavior by element type:
+- **Goal**: fetch goal -> derive related stories (direct + from goal tasks) -> de-duplicate.
+- **Task**: if task has story relation, return that story as list of one; otherwise empty.
+- **Story**: treat current story as selected and load its tasks directly.
+
+Data normalization:
+- Map API DTOs into lightweight list VMs (`id`, `uuid`, `title`, `status`, `isOnCanvas`).
+- `isOnCanvas` computed from current `scene.getElements()` snapshot.
+
+### 5) Implement 3-column Details UI state machine
+
+State in `ElementDetailsModal`:
+- `stories`, `tasks`, `selectedStoryRef`, loading/error states per column.
+
+Flow:
+1. On open -> set skeleton state.
+2. Load stories for selected element.
+3. Auto-select first story (if exists).
+4. Load tasks for selected story.
+5. On user selecting another story -> reload tasks column only.
+
+Important UX behavior:
+- Keep old tasks visible during next story load (soft loading indicator), avoid harsh empty flicker.
+- Column-level errors (e.g. tasks failed) should not close modal or clear successful stories.
+
+### 6) “Open on canvas” and “Add to canvas” actions
+
+Open on canvas:
+- If entity exists in scene (`backendId/uuid` match), call canvas pan/zoom manager to center and select element.
+
+Add to canvas:
+- Reuse existing add services:
+  - `AddExistingTaskService`
+  - `AddExistingStoryService`
+- Trigger same command flow as current existing pickers to keep undo/redo consistency.
+
+### 7) Story view parity requirement
+
+Requested requirement:
+- “For view stories show story tasks identically”.
+
+Implementation decision:
+- Reuse the **same `RelatedTaskList` component** used in column C.
+- For Story details, hide Stories column and pin selected story to current story context.
+
+This guarantees visual and behavioral parity without duplicate UI logic.
+
+### 8) Test strategy before merge
+
+Unit tests:
+- `ElementDetailsService`:
+  - goal->stories mapping,
+  - de-duplication behavior,
+  - error isolation,
+  - stale request cancellation (`switchMap`) semantics.
+
+Component tests:
+- Details modal renders empty/loading/success/error per column.
+- Story selection updates tasks column.
+
+Regression checks:
+- Existing `EditElementModal` save/unsaved-guard behavior unaffected.
+- Existing `RelatedItemsPicker` still works after helper extraction.

--- a/src/features/canvas/core/eventBus.ts
+++ b/src/features/canvas/core/eventBus.ts
@@ -7,3 +7,8 @@ import type { GoalElement } from '../elements/GoalElement.ts';
 export const editElement$ = new Subject<
   TaskElement | StoryElement | GoalElement
 >();
+
+// Central bus for read-only details view
+export const viewElementDetails$ = new Subject<
+  TaskElement | StoryElement | GoalElement
+>();

--- a/src/features/canvas/core/services/ElementDetailsService.ts
+++ b/src/features/canvas/core/services/ElementDetailsService.ts
@@ -1,0 +1,136 @@
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { GoalElement } from '../../elements/GoalElement.ts';
+import { StoryElement } from '../../elements/StoryElement.ts';
+import { TaskElement } from '../../elements/TaskElement.ts';
+import { GoalsApiService } from '../../../../majom-wrapper/data-access/goals-api-service.ts';
+import { StoriesApiService } from '../../../../majom-wrapper/data-access/stories-api-service.ts';
+import type { Goal, PlatformTask, Story } from '../../../../majom-wrapper/interfaces/index.ts';
+import {
+  collectStoriesFromGoalTasks,
+  mergeStoriesDedup,
+  normalizeBackendRef,
+  type BackendRef,
+} from './relationshipResolvers.ts';
+import { Scene } from '../scene/Scene.ts';
+
+type CanvasElement = TaskElement | StoryElement | GoalElement;
+
+export type StoryListItemVM = {
+  id: number;
+  uuid?: string;
+  title: string;
+  status?: string;
+  tasksCount: number;
+  isOnCanvas: boolean;
+};
+
+export type TaskListItemVM = {
+  id: number;
+  uuid?: string;
+  title: string;
+  status?: string;
+  isOnCanvas: boolean;
+};
+
+export class ElementDetailsService {
+  constructor(
+    private readonly scene: Scene,
+    private readonly goalsApi: GoalsApiService,
+    private readonly storiesApi: StoriesApiService
+  ) {}
+
+  public loadStoriesForElement(element: CanvasElement): Observable<StoryListItemVM[]> {
+    if (element instanceof StoryElement) {
+      const id = Number.isFinite(element.backendId) ? (element.backendId as number) : null;
+      if (id === null) return of([]);
+      return this.storiesApi.getStory(id).pipe(
+        map((story) => [this.mapStory(story)]),
+        catchError(() => of([]))
+      );
+    }
+
+    if (element instanceof TaskElement) {
+      return this.getTaskStoryList(element);
+    }
+
+    return this.getGoalStories(element);
+  }
+
+  public loadTasksForStory(ref: BackendRef): Observable<TaskListItemVM[]> {
+    const normalizedRef = normalizeBackendRef(ref);
+    if (normalizedRef.id === null) return of([]);
+    return this.storiesApi.getStory(normalizedRef.id).pipe(
+      map((story) => (Array.isArray(story.tasks) ? story.tasks : []).map((task) => this.mapTask(task))),
+      catchError(() => of([]))
+    );
+  }
+
+  private getTaskStoryList(element: TaskElement): Observable<StoryListItemVM[]> {
+    if (!Number.isFinite(element.backendId)) return of([]);
+    return this.storiesApi
+      .fetchStories({ page: 1, pageSize: 20 })
+      .pipe(
+        map((response) => response.results || []),
+        map((stories) =>
+          stories.filter((story) =>
+            (story.tasks || []).some((task) => task.id === element.backendId)
+          )
+        ),
+        map((stories) => stories.map((story) => this.mapStory(story))),
+        catchError(() => of([]))
+      );
+  }
+
+  private getGoalStories(element: GoalElement): Observable<StoryListItemVM[]> {
+    if (!Number.isFinite(element.backendId)) return of([]);
+    return this.goalsApi.getGoal(element.backendId as number).pipe(
+      map((goal) => this.extractGoalStories(goal)),
+      map((stories) => stories.map((story) => this.mapStory(story))),
+      catchError(() => of([]))
+    );
+  }
+
+  private extractGoalStories(goal: Goal): Story[] {
+    const directStories = Array.isArray(goal.stories) ? goal.stories : [];
+    const fromTasks = collectStoriesFromGoalTasks(goal);
+    return mergeStoriesDedup(directStories, fromTasks);
+  }
+
+  private mapStory(story: Story): StoryListItemVM {
+    return {
+      id: story.id,
+      uuid: story.uuid,
+      title: story.title,
+      status: String(story.status ?? ''),
+      tasksCount: Array.isArray(story.tasks) ? story.tasks.length : 0,
+      isOnCanvas: this.hasStoryOnCanvas(story),
+    };
+  }
+
+  private mapTask(task: PlatformTask): TaskListItemVM {
+    return {
+      id: task.id,
+      uuid: task.uuid,
+      title: task.title,
+      status: String(task.status ?? ''),
+      isOnCanvas: this.hasTaskOnCanvas(task),
+    };
+  }
+
+  private hasStoryOnCanvas(story: Story): boolean {
+    return this.scene.getElements().some((el) => {
+      if (!(el instanceof StoryElement)) return false;
+      if (story.uuid && el.uuid && story.uuid === el.uuid) return true;
+      return Number.isFinite(el.backendId) && el.backendId === story.id;
+    });
+  }
+
+  private hasTaskOnCanvas(task: PlatformTask): boolean {
+    return this.scene.getElements().some((el) => {
+      if (!(el instanceof TaskElement)) return false;
+      if (task.uuid && el.uuid && task.uuid === el.uuid) return true;
+      return Number.isFinite(el.backendId) && el.backendId === task.id;
+    });
+  }
+}

--- a/src/features/canvas/core/services/ElementDetailsService.ts
+++ b/src/features/canvas/core/services/ElementDetailsService.ts
@@ -1,13 +1,18 @@
 import { Observable, of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { catchError, map, shareReplay } from 'rxjs/operators';
 import { GoalElement } from '../../elements/GoalElement.ts';
 import { StoryElement } from '../../elements/StoryElement.ts';
 import { TaskElement } from '../../elements/TaskElement.ts';
 import { GoalsApiService } from '../../../../majom-wrapper/data-access/goals-api-service.ts';
 import { StoriesApiService } from '../../../../majom-wrapper/data-access/stories-api-service.ts';
-import type { Goal, PlatformTask, Story } from '../../../../majom-wrapper/interfaces/index.ts';
+import type {
+  Goal,
+  PlatformTask,
+  Story,
+} from '../../../../majom-wrapper/interfaces/index.ts';
 import {
   collectStoriesFromGoalTasks,
+  matchesRef,
   mergeStoriesDedup,
   normalizeBackendRef,
   type BackendRef,
@@ -34,20 +39,48 @@ export type TaskListItemVM = {
 };
 
 export class ElementDetailsService {
+  private readonly storiesCache = new Map<string, Observable<StoryListItemVM[]>>();
+  private readonly tasksCache = new Map<string, Observable<TaskListItemVM[]>>();
+
   constructor(
     private readonly scene: Scene,
     private readonly goalsApi: GoalsApiService,
     private readonly storiesApi: StoriesApiService
   ) {}
 
-  public loadStoriesForElement(element: CanvasElement): Observable<StoryListItemVM[]> {
+  public loadStoriesForElement(
+    element: CanvasElement
+  ): Observable<StoryListItemVM[]> {
+    const key = this.getElementCacheKey(element);
+    const cached = this.storiesCache.get(key);
+    if (cached) return cached;
+
+    const source = this.loadStoriesForElementUncached(element).pipe(
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
+    this.storiesCache.set(key, source);
+    return source;
+  }
+
+  public loadTasksForStory(ref: BackendRef): Observable<TaskListItemVM[]> {
+    const normalizedRef = normalizeBackendRef(ref);
+    const cacheKey = this.getStoryRefKey(normalizedRef);
+    const cached = this.tasksCache.get(cacheKey);
+    if (cached) return cached;
+
+    const source = this.loadTasksForStoryUncached(normalizedRef).pipe(
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
+    this.tasksCache.set(cacheKey, source);
+    return source;
+  }
+
+  private loadStoriesForElementUncached(
+    element: CanvasElement
+  ): Observable<StoryListItemVM[]> {
     if (element instanceof StoryElement) {
-      const id = Number.isFinite(element.backendId) ? (element.backendId as number) : null;
-      if (id === null) return of([]);
-      return this.storiesApi.getStory(id).pipe(
-        map((story) => [this.mapStory(story)]),
-        catchError(() => of([]))
-      );
+      const ref = normalizeBackendRef({ id: element.backendId, uuid: element.uuid });
+      return this.loadSingleStory(ref);
     }
 
     if (element instanceof TaskElement) {
@@ -57,34 +90,67 @@ export class ElementDetailsService {
     return this.getGoalStories(element);
   }
 
-  public loadTasksForStory(ref: BackendRef): Observable<TaskListItemVM[]> {
-    const normalizedRef = normalizeBackendRef(ref);
-    if (normalizedRef.id === null) return of([]);
-    return this.storiesApi.getStory(normalizedRef.id).pipe(
-      map((story) => (Array.isArray(story.tasks) ? story.tasks : []).map((task) => this.mapTask(task))),
+  private loadTasksForStoryUncached(ref: BackendRef): Observable<TaskListItemVM[]> {
+    if (ref.id !== null) {
+      return this.storiesApi.getStory(ref.id).pipe(
+        map((story) =>
+          (Array.isArray(story.tasks) ? story.tasks : []).map((task) =>
+            this.mapTask(task)
+          )
+        ),
+        catchError(() => of([]))
+      );
+    }
+
+    if (ref.uuid) {
+      return this.storiesApi.fetchStoriesByUuids([ref.uuid]).pipe(
+        map((stories) => stories[0]),
+        map((story) => (story && Array.isArray(story.tasks) ? story.tasks : [])),
+        map((tasks) => tasks.map((task) => this.mapTask(task))),
+        catchError(() => of([]))
+      );
+    }
+
+    return of([]);
+  }
+
+  private loadSingleStory(ref: BackendRef): Observable<StoryListItemVM[]> {
+    if (ref.id !== null) {
+      return this.storiesApi.getStory(ref.id).pipe(
+        map((story) => [this.mapStory(story)]),
+        catchError(() => of([]))
+      );
+    }
+
+    if (ref.uuid) {
+      return this.storiesApi.fetchStoriesByUuids([ref.uuid]).pipe(
+        map((stories) => stories.map((story) => this.mapStory(story))),
+        catchError(() => of([]))
+      );
+    }
+
+    return of([]);
+  }
+
+  private getTaskStoryList(element: TaskElement): Observable<StoryListItemVM[]> {
+    const taskRef = normalizeBackendRef({ id: element.backendId, uuid: element.uuid });
+    if (taskRef.id === null && !taskRef.uuid) return of([]);
+
+    return this.storiesApi.getStories().pipe(
+      map((stories) =>
+        stories.filter((story) =>
+          (story.tasks || []).some((task) => matchesRef(task, taskRef))
+        )
+      ),
+      map((stories) => stories.map((story) => this.mapStory(story))),
       catchError(() => of([]))
     );
   }
 
-  private getTaskStoryList(element: TaskElement): Observable<StoryListItemVM[]> {
-    if (!Number.isFinite(element.backendId)) return of([]);
-    return this.storiesApi
-      .fetchStories({ page: 1, pageSize: 20 })
-      .pipe(
-        map((response) => response.results || []),
-        map((stories) =>
-          stories.filter((story) =>
-            (story.tasks || []).some((task) => task.id === element.backendId)
-          )
-        ),
-        map((stories) => stories.map((story) => this.mapStory(story))),
-        catchError(() => of([]))
-      );
-  }
-
   private getGoalStories(element: GoalElement): Observable<StoryListItemVM[]> {
-    if (!Number.isFinite(element.backendId)) return of([]);
-    return this.goalsApi.getGoal(element.backendId as number).pipe(
+    const ref = normalizeBackendRef({ id: element.backendId, uuid: element.uuid });
+    if (ref.id === null) return of([]);
+    return this.goalsApi.getGoal(ref.id).pipe(
       map((goal) => this.extractGoalStories(goal)),
       map((stories) => stories.map((story) => this.mapStory(story))),
       catchError(() => of([]))
@@ -132,5 +198,17 @@ export class ElementDetailsService {
       if (task.uuid && el.uuid && task.uuid === el.uuid) return true;
       return Number.isFinite(el.backendId) && el.backendId === task.id;
     });
+  }
+
+  private getElementCacheKey(element: CanvasElement): string {
+    if (element.uuid) return `uuid:${element.uuid}`;
+    if (Number.isFinite(element.backendId)) return `id:${String(element.backendId)}`;
+    return `canvas:${element.id}`;
+  }
+
+  private getStoryRefKey(ref: BackendRef): string {
+    if (ref.uuid) return `uuid:${ref.uuid}`;
+    if (ref.id !== null) return `id:${String(ref.id)}`;
+    return 'empty';
   }
 }

--- a/src/features/canvas/core/services/relationshipResolvers.ts
+++ b/src/features/canvas/core/services/relationshipResolvers.ts
@@ -1,0 +1,46 @@
+import type { Goal, PlatformTask, Story } from '../../../majom-wrapper/interfaces/index.ts';
+
+export type BackendRef = {
+  id: number | null;
+  uuid: string | null;
+};
+
+export const normalizeBackendRef = (
+  input: Partial<BackendRef>
+): BackendRef => ({
+  id: Number.isFinite(input.id) ? (input.id as number) : null,
+  uuid:
+    typeof input.uuid === 'string' && input.uuid.trim().length > 0
+      ? input.uuid
+      : null,
+});
+
+export const collectStoriesFromGoalTasks = (goal: Goal): Story[] => {
+  const stories: Story[] = [];
+  const seenIds = new Set<number>();
+  const tasks = Array.isArray(goal.tasks) ? goal.tasks : [];
+  tasks.forEach((task) => {
+    const story = (task as PlatformTask).story;
+    if (!story || !Number.isFinite(story.id)) return;
+    if (seenIds.has(story.id)) return;
+    seenIds.add(story.id);
+    stories.push(story);
+  });
+  return stories;
+};
+
+export const mergeStoriesDedup = (primary: Story[], secondary: Story[]): Story[] => {
+  const merged = new Map<number, Story>();
+  primary.forEach((story) => merged.set(story.id, story));
+  secondary.forEach((story) => merged.set(story.id, story));
+  return Array.from(merged.values());
+};
+
+export const matchesRef = (
+  item: { id?: number; uuid?: string },
+  ref: BackendRef
+): boolean => {
+  if (ref.uuid && item.uuid === ref.uuid) return true;
+  if (ref.id !== null && Number.isFinite(item.id) && item.id === ref.id) return true;
+  return false;
+};

--- a/src/features/canvas/core/services/relationshipResolvers.ts
+++ b/src/features/canvas/core/services/relationshipResolvers.ts
@@ -1,13 +1,15 @@
-import type { Goal, PlatformTask, Story } from '../../../majom-wrapper/interfaces/index.ts';
+import type {
+  Goal,
+  PlatformTask,
+  Story,
+} from '../../../../majom-wrapper/interfaces/index.ts';
 
 export type BackendRef = {
   id: number | null;
   uuid: string | null;
 };
 
-export const normalizeBackendRef = (
-  input: Partial<BackendRef>
-): BackendRef => ({
+export const normalizeBackendRef = (input: Partial<BackendRef>): BackendRef => ({
   id: Number.isFinite(input.id) ? (input.id as number) : null,
   uuid:
     typeof input.uuid === 'string' && input.uuid.trim().length > 0
@@ -29,7 +31,10 @@ export const collectStoriesFromGoalTasks = (goal: Goal): Story[] => {
   return stories;
 };
 
-export const mergeStoriesDedup = (primary: Story[], secondary: Story[]): Story[] => {
+export const mergeStoriesDedup = (
+  primary: Story[],
+  secondary: Story[]
+): Story[] => {
   const merged = new Map<number, Story>();
   primary.forEach((story) => merged.set(story.id, story));
   secondary.forEach((story) => merged.set(story.id, story));
@@ -41,6 +46,8 @@ export const matchesRef = (
   ref: BackendRef
 ): boolean => {
   if (ref.uuid && item.uuid === ref.uuid) return true;
-  if (ref.id !== null && Number.isFinite(item.id) && item.id === ref.id) return true;
+  if (ref.id !== null && Number.isFinite(item.id) && item.id === ref.id) {
+    return true;
+  }
   return false;
 };

--- a/src/features/canvas/ui/ContextMenu.ts
+++ b/src/features/canvas/ui/ContextMenu.ts
@@ -18,6 +18,7 @@ import { positionFixedElement } from './overlayPosition.ts';
 import { BulkActionsController } from '../core/services/BulkActionsController.ts';
 import { ElementStatus } from '../elements/ElementStatus.ts';
 import { addTaskToStory } from './storyTaskActions.ts';
+import { viewElementDetails$ } from '../core/eventBus.ts';
 import { ExistingTaskPicker } from './components/ExistingTaskPicker.ts';
 import { ExistingGoalPicker } from './components/ExistingGoalPicker.ts';
 import { ExistingStoryPicker } from './components/ExistingStoryPicker.ts';
@@ -280,6 +281,14 @@ export class ContextMenu {
         label: 'Edit',
         action: () => {
           (element as any).onDoubleClick?.();
+        },
+      });
+      actionItems.push({
+        label: 'View details',
+        action: () => {
+          viewElementDetails$.next(
+            element as TaskElement | StoryElement | GoalElement
+          );
         },
       });
     }

--- a/src/features/canvas/ui/UIManager.ts
+++ b/src/features/canvas/ui/UIManager.ts
@@ -1,11 +1,12 @@
 // ui/UIManager.ts
 import { CanvasNavigationDock } from './CanvasNavigationDock.ts';
 import { EditElementModal } from './components/EditElementModal.ts';
+import { ElementDetailsModal } from './components/ElementDetailsModal.ts';
 import { NotificationContainer } from './components/NotificationContainer.ts';
 import { CanvasBoardSelector } from './components/CanvasBoardSelector.ts';
 import { CanvasManager } from '../core/managers/CanvasManager.ts';
 import { Scene } from '../core/scene/Scene.ts';
-import { editElement$ } from '../core/eventBus.ts';
+import { editElement$, viewElementDetails$ } from '../core/eventBus.ts';
 import { SaveControls } from './components/SaveControls.ts';
 import { ContextMenu } from './ContextMenu.ts';
 import { SelectionActionMenu } from './SelectionActionMenu.ts';
@@ -64,6 +65,7 @@ export class UIManager {
   private canvasDropHandler: ((event: DragEvent) => void) | null = null;
   private uiRoot: HTMLDivElement | null = null;
   private editElementSubscription: Subscription | null = null;
+  private viewElementDetailsSubscription: Subscription | null = null;
 
   constructor(
     private readonly canvasManager: CanvasManager,
@@ -183,6 +185,9 @@ export class UIManager {
     this.editElementSubscription = editElement$.subscribe((el) =>
       new EditElementModal(el, this.scene).show()
     );
+    this.viewElementDetailsSubscription = viewElementDetails$.subscribe((el) =>
+      new ElementDetailsModal(el, this.scene).show()
+    );
   }
 
   public mountAll(parent: HTMLElement = document.body): void {
@@ -247,6 +252,8 @@ export class UIManager {
     this.components.forEach((c) => c.unmount());
     this.editElementSubscription?.unsubscribe();
     this.editElementSubscription = null;
+    this.viewElementDetailsSubscription?.unsubscribe();
+    this.viewElementDetailsSubscription = null;
     if (this.existingPickerDragStateHandler) {
       window.removeEventListener(
         EXISTING_PICKER_EVENT_NAMES.dragStateChanged,

--- a/src/features/canvas/ui/components/ElementDetailsModal.ts
+++ b/src/features/canvas/ui/components/ElementDetailsModal.ts
@@ -1,0 +1,217 @@
+import { GoalElement } from '../../elements/GoalElement.ts';
+import { StoryElement } from '../../elements/StoryElement.ts';
+import { TaskElement } from '../../elements/TaskElement.ts';
+import { Scene } from '../../core/scene/Scene.ts';
+import {
+  createModalActionRow,
+  createModalShell,
+  getModalActionButtonClass,
+} from '../../../../ui-lib/src/components/Modal.ts';
+import { createTextButton } from '../primitives/index.ts';
+import {
+  ElementDetailsService,
+  type StoryListItemVM,
+  type TaskListItemVM,
+} from '../../core/services/ElementDetailsService.ts';
+import { environment } from '../../../../config/environment.ts';
+import { HttpInterceptorClient } from '../../../../majom-wrapper/data-access/http-interceptor.ts';
+import { GoalsApiService } from '../../../../majom-wrapper/data-access/goals-api-service.ts';
+import { StoriesApiService } from '../../../../majom-wrapper/data-access/stories-api-service.ts';
+import { Subscription } from 'rxjs';
+
+type CanvasElement = TaskElement | StoryElement | GoalElement;
+
+export class ElementDetailsModal {
+  private modal: HTMLDivElement | null = null;
+  private readonly detailsService: ElementDetailsService;
+  private subscriptions: Subscription[] = [];
+
+  constructor(
+    private readonly element: CanvasElement,
+    private readonly scene: Scene
+  ) {
+    const http = new HttpInterceptorClient(environment.apiUrl);
+    this.detailsService = new ElementDetailsService(
+      scene,
+      new GoalsApiService(http),
+      new StoriesApiService(http)
+    );
+  }
+
+  public show(): void {
+    const { overlay, container, body, footer } = createModalShell(
+      `${this.getTypeLabel()} details`,
+      {
+        onClose: () => this.close(),
+        intent: 'info',
+      }
+    );
+    this.modal = overlay;
+    container.classList.add('max-w-6xl');
+
+    const root = document.createElement('div');
+    root.className = 'grid grid-cols-1 gap-3 md:grid-cols-3';
+    body.appendChild(root);
+
+    const summaryCol = this.createColumn('Element');
+    summaryCol.content.appendChild(this.renderSummary());
+    root.appendChild(summaryCol.element);
+
+    const storiesCol = this.createColumn('Stories');
+    const tasksCol = this.createColumn('Tasks');
+    root.append(storiesCol.element, tasksCol.element);
+
+    const actions = createModalActionRow({ variant: 'form' });
+    const closeBtn = createTextButton({
+      text: 'Close',
+      tone: 'primary',
+      size: 'md',
+      className: getModalActionButtonClass('default'),
+      onClick: () => this.close(),
+    });
+    actions.appendChild(closeBtn);
+    footer.appendChild(actions);
+
+    const renderTasks = (stories: StoryListItemVM[]): void => {
+      if (stories.length === 0) {
+        this.renderMessage(tasksCol.content, 'No tasks to display');
+        return;
+      }
+      const first = stories[0];
+      this.renderMessage(tasksCol.content, 'Loading tasks...');
+      const sub = this.detailsService
+        .loadTasksForStory({ id: first.id, uuid: first.uuid ?? null })
+        .subscribe((tasks) => this.renderTaskList(tasksCol.content, tasks));
+      this.subscriptions.push(sub);
+    };
+
+    if (this.element instanceof StoryElement) {
+      this.renderMessage(storiesCol.content, 'Current story');
+      const refId = Number.isFinite(this.element.backendId)
+        ? (this.element.backendId as number)
+        : null;
+      if (refId === null) {
+        this.renderMessage(tasksCol.content, 'Story is not linked to backend yet');
+      } else {
+        const sub = this.detailsService
+          .loadTasksForStory({ id: refId, uuid: this.element.uuid ?? null })
+          .subscribe((tasks) => this.renderTaskList(tasksCol.content, tasks));
+        this.subscriptions.push(sub);
+      }
+      return;
+    }
+
+    this.renderMessage(storiesCol.content, 'Loading stories...');
+    this.renderMessage(tasksCol.content, 'Select a story');
+    const storiesSub = this.detailsService
+      .loadStoriesForElement(this.element)
+      .subscribe((stories) => {
+        this.renderStoriesList(storiesCol.content, stories, (story) => {
+          this.renderMessage(tasksCol.content, 'Loading tasks...');
+          const sub = this.detailsService
+            .loadTasksForStory({ id: story.id, uuid: story.uuid ?? null })
+            .subscribe((tasks) => this.renderTaskList(tasksCol.content, tasks));
+          this.subscriptions.push(sub);
+        });
+        renderTasks(stories);
+      });
+    this.subscriptions.push(storiesSub);
+  }
+
+  private renderSummary(): HTMLElement {
+    const wrap = document.createElement('div');
+    wrap.className = 'space-y-2 text-sm';
+    const rows: Array<[string, string]> = [
+      ['Type', this.getTypeLabel()],
+      ['Title', this.element.title],
+      ['Status', this.element.status],
+      ['Description', this.element.description || '—'],
+    ];
+    rows.forEach(([label, value]) => {
+      const row = document.createElement('div');
+      row.className = 'rounded-md bg-slate-50 p-2';
+      row.innerHTML = `<div class="text-xs uppercase text-slate-500">${label}</div><div class="text-slate-900">${value}</div>`;
+      wrap.appendChild(row);
+    });
+    return wrap;
+  }
+
+  private renderStoriesList(
+    container: HTMLElement,
+    stories: StoryListItemVM[],
+    onSelect: (story: StoryListItemVM) => void
+  ): void {
+    container.innerHTML = '';
+    if (stories.length === 0) {
+      this.renderMessage(container, 'No related stories');
+      return;
+    }
+    const list = document.createElement('div');
+    list.className = 'space-y-1';
+    stories.forEach((story, index) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className =
+        'w-full rounded-md border border-slate-200 px-2 py-2 text-left text-sm hover:bg-slate-50';
+      btn.innerHTML = `<div class="font-medium text-slate-900">${story.title}</div><div class="text-xs text-slate-500">Tasks: ${story.tasksCount} · ${story.isOnCanvas ? 'On canvas' : 'Not on canvas'}</div>`;
+      btn.addEventListener('click', () => onSelect(story));
+      if (index === 0) {
+        btn.classList.add('bg-indigo-50', 'border-indigo-200');
+      }
+      list.appendChild(btn);
+    });
+    container.appendChild(list);
+  }
+
+  private renderTaskList(container: HTMLElement, tasks: TaskListItemVM[]): void {
+    container.innerHTML = '';
+    if (tasks.length === 0) {
+      this.renderMessage(container, 'No tasks in this story');
+      return;
+    }
+    const list = document.createElement('div');
+    list.className = 'space-y-1';
+    tasks.forEach((task) => {
+      const item = document.createElement('div');
+      item.className = 'rounded-md border border-slate-200 px-2 py-2 text-sm';
+      item.innerHTML = `<div class="font-medium text-slate-900">${task.title}</div><div class="text-xs text-slate-500">${task.isOnCanvas ? 'On canvas' : 'Not on canvas'}</div>`;
+      list.appendChild(item);
+    });
+    container.appendChild(list);
+  }
+
+  private renderMessage(container: HTMLElement, text: string): void {
+    container.innerHTML = '';
+    const empty = document.createElement('div');
+    empty.className = 'rounded-md border border-dashed border-slate-300 p-3 text-sm text-slate-500';
+    empty.textContent = text;
+    container.appendChild(empty);
+  }
+
+  private createColumn(title: string): { element: HTMLDivElement; content: HTMLDivElement } {
+    const element = document.createElement('div');
+    element.className = 'rounded-xl border border-slate-200 p-3';
+    const heading = document.createElement('h3');
+    heading.className = 'mb-2 text-sm font-semibold text-slate-900';
+    heading.textContent = title;
+    const content = document.createElement('div');
+    content.className = 'min-h-[220px]';
+    element.append(heading, content);
+    return { element, content };
+  }
+
+  private getTypeLabel(): string {
+    if (this.element instanceof TaskElement) return 'Task';
+    if (this.element instanceof StoryElement) return 'Story';
+    return 'Goal';
+  }
+
+  private close(): void {
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
+    this.subscriptions = [];
+    if (this.modal) {
+      this.modal.remove();
+      this.modal = null;
+    }
+  }
+}

--- a/src/features/canvas/ui/components/ElementDetailsModal.ts
+++ b/src/features/canvas/ui/components/ElementDetailsModal.ts
@@ -17,7 +17,7 @@ import { environment } from '../../../../config/environment.ts';
 import { HttpInterceptorClient } from '../../../../majom-wrapper/data-access/http-interceptor.ts';
 import { GoalsApiService } from '../../../../majom-wrapper/data-access/goals-api-service.ts';
 import { StoriesApiService } from '../../../../majom-wrapper/data-access/stories-api-service.ts';
-import { Subscription } from 'rxjs';
+import type { Subscription } from 'rxjs';
 
 type CanvasElement = TaskElement | StoryElement | GoalElement;
 
@@ -25,6 +25,8 @@ export class ElementDetailsModal {
   private modal: HTMLDivElement | null = null;
   private readonly detailsService: ElementDetailsService;
   private subscriptions: Subscription[] = [];
+  private storyTasksSubscription: Subscription | null = null;
+  private selectedStoryId: number | null = null;
 
   constructor(
     private readonly element: CanvasElement,
@@ -72,31 +74,18 @@ export class ElementDetailsModal {
     actions.appendChild(closeBtn);
     footer.appendChild(actions);
 
-    const renderTasks = (stories: StoryListItemVM[]): void => {
-      if (stories.length === 0) {
-        this.renderMessage(tasksCol.content, 'No tasks to display');
-        return;
-      }
-      const first = stories[0];
-      this.renderMessage(tasksCol.content, 'Loading tasks...');
-      const sub = this.detailsService
-        .loadTasksForStory({ id: first.id, uuid: first.uuid ?? null })
-        .subscribe((tasks) => this.renderTaskList(tasksCol.content, tasks));
-      this.subscriptions.push(sub);
-    };
-
     if (this.element instanceof StoryElement) {
       this.renderMessage(storiesCol.content, 'Current story');
       const refId = Number.isFinite(this.element.backendId)
         ? (this.element.backendId as number)
         : null;
       if (refId === null) {
-        this.renderMessage(tasksCol.content, 'Story is not linked to backend yet');
+        this.renderMessage(
+          tasksCol.content,
+          'Story is not linked to backend yet'
+        );
       } else {
-        const sub = this.detailsService
-          .loadTasksForStory({ id: refId, uuid: this.element.uuid ?? null })
-          .subscribe((tasks) => this.renderTaskList(tasksCol.content, tasks));
-        this.subscriptions.push(sub);
+        this.loadTasks(tasksCol.content, { id: refId, uuid: this.element.uuid });
       }
       return;
     }
@@ -106,16 +95,31 @@ export class ElementDetailsModal {
     const storiesSub = this.detailsService
       .loadStoriesForElement(this.element)
       .subscribe((stories) => {
-        this.renderStoriesList(storiesCol.content, stories, (story) => {
-          this.renderMessage(tasksCol.content, 'Loading tasks...');
-          const sub = this.detailsService
-            .loadTasksForStory({ id: story.id, uuid: story.uuid ?? null })
-            .subscribe((tasks) => this.renderTaskList(tasksCol.content, tasks));
-          this.subscriptions.push(sub);
-        });
-        renderTasks(stories);
+        if (stories.length === 0) {
+          this.selectedStoryId = null;
+          this.renderMessage(tasksCol.content, 'No tasks to display');
+        } else {
+          this.selectedStoryId = stories[0].id;
+          this.loadTasks(tasksCol.content, {
+            id: stories[0].id,
+            uuid: stories[0].uuid,
+          });
+        }
+        this.renderStoriesList(storiesCol.content, stories, tasksCol.content);
       });
     this.subscriptions.push(storiesSub);
+  }
+
+  private loadTasks(
+    container: HTMLElement,
+    ref: { id: number; uuid?: string }
+  ): void {
+    this.storyTasksSubscription?.unsubscribe();
+    this.renderMessage(container, 'Loading tasks...');
+    this.storyTasksSubscription = this.detailsService
+      .loadTasksForStory({ id: ref.id, uuid: ref.uuid ?? null })
+      .subscribe((tasks) => this.renderTaskList(container, tasks));
+    this.subscriptions.push(this.storyTasksSubscription);
   }
 
   private renderSummary(): HTMLElement {
@@ -139,7 +143,7 @@ export class ElementDetailsModal {
   private renderStoriesList(
     container: HTMLElement,
     stories: StoryListItemVM[],
-    onSelect: (story: StoryListItemVM) => void
+    tasksContainer: HTMLElement
   ): void {
     container.innerHTML = '';
     if (stories.length === 0) {
@@ -148,16 +152,23 @@ export class ElementDetailsModal {
     }
     const list = document.createElement('div');
     list.className = 'space-y-1';
-    stories.forEach((story, index) => {
+    stories.forEach((story) => {
       const btn = document.createElement('button');
       btn.type = 'button';
+      const selected = this.selectedStoryId === story.id;
       btn.className =
-        'w-full rounded-md border border-slate-200 px-2 py-2 text-left text-sm hover:bg-slate-50';
-      btn.innerHTML = `<div class="font-medium text-slate-900">${story.title}</div><div class="text-xs text-slate-500">Tasks: ${story.tasksCount} · ${story.isOnCanvas ? 'On canvas' : 'Not on canvas'}</div>`;
-      btn.addEventListener('click', () => onSelect(story));
-      if (index === 0) {
-        btn.classList.add('bg-indigo-50', 'border-indigo-200');
+        'w-full rounded-md border px-2 py-2 text-left text-sm hover:bg-slate-50';
+      if (selected) {
+        btn.classList.add('border-indigo-200', 'bg-indigo-50');
+      } else {
+        btn.classList.add('border-slate-200');
       }
+      btn.innerHTML = `<div class="font-medium text-slate-900">${story.title}</div><div class="text-xs text-slate-500">Tasks: ${story.tasksCount} · ${story.isOnCanvas ? 'On canvas' : 'Not on canvas'}</div>`;
+      btn.addEventListener('click', () => {
+        this.selectedStoryId = story.id;
+        this.renderStoriesList(container, stories, tasksContainer);
+        this.loadTasks(tasksContainer, { id: story.id, uuid: story.uuid });
+      });
       list.appendChild(btn);
     });
     container.appendChild(list);
@@ -183,12 +194,15 @@ export class ElementDetailsModal {
   private renderMessage(container: HTMLElement, text: string): void {
     container.innerHTML = '';
     const empty = document.createElement('div');
-    empty.className = 'rounded-md border border-dashed border-slate-300 p-3 text-sm text-slate-500';
+    empty.className =
+      'rounded-md border border-dashed border-slate-300 p-3 text-sm text-slate-500';
     empty.textContent = text;
     container.appendChild(empty);
   }
 
-  private createColumn(title: string): { element: HTMLDivElement; content: HTMLDivElement } {
+  private createColumn(
+    title: string
+  ): { element: HTMLDivElement; content: HTMLDivElement } {
     const element = document.createElement('div');
     element.className = 'rounded-xl border border-slate-200 p-3';
     const heading = document.createElement('h3');
@@ -207,6 +221,8 @@ export class ElementDetailsModal {
   }
 
   private close(): void {
+    this.storyTasksSubscription?.unsubscribe();
+    this.storyTasksSubscription = null;
     this.subscriptions.forEach((sub) => sub.unsubscribe());
     this.subscriptions = [];
     if (this.modal) {


### PR DESCRIPTION
### Motivation

- Provide a read-only, exploration-focused details UI that shows related stories and story tasks for Goals/Tasks/Stories without coupling to the existing edit form.
- Centralize relationship and data orchestration logic so the UI remains presentational and reuses existing backend services (`StoriesApiService`, `GoalsApiService`).
- Make details accessible from existing context menus and UI flows while preserving the current `EditElementModal` behavior.

### Description

- Added a UX/architecture plan document `docs/ELEMENT-DETAILS-UX-IMPLEMENTATION-PLAN.md` describing goals, interaction model, and phased rollout.
- Introduced `viewElementDetails$` event in `eventBus.ts` and wired a context-menu item to emit it from `ContextMenu.ts` so users can open the details view via "View details".
- Implemented `ElementDetailsModal` UI component `src/features/canvas/ui/components/ElementDetailsModal.ts` that renders a 3-column read-only modal (summary, related stories, story tasks) and subscribes to `ElementDetailsService` for data.
- Implemented `ElementDetailsService` `src/features/canvas/core/services/ElementDetailsService.ts` to orchestrate loading and mapping of stories and tasks, compute `isOnCanvas`, and use `GoalsApiService`/`StoriesApiService` for backend hydration.
- Extracted pure relationship helper utilities into `src/features/canvas/core/services/relationshipResolvers.ts` for ref normalization, collecting stories from goal tasks, deduping and ref matching.
- Wired modal lifecycle into `UIManager.ts` to subscribe to `viewElementDetails$`, show the `ElementDetailsModal`, and clean up subscriptions on unmount.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a605b36da08331b0a82ee29dc84a38)