### PR TITLE
Add Routine (Habit) element type to Canvas: element, picker, persistence and UI

### DIFF
--- a/docs/ROUTINE-ELEMENT-ON-CANVAS.md
+++ b/docs/ROUTINE-ELEMENT-ON-CANVAS.md
@@ -1,0 +1,174 @@
+# Додавання нового елемента **Routine (Habit)** на Canvas
+
+Цей документ описує, де саме в коді потрібно внести зміни, щоб додати новий тип елемента `RoutineElement` у Canvas (на рівні моделі, рендера, контекстного меню та інтеграції з existing-picker).
+
+## API статус по routines
+
+Так — API для routines/habits уже є в проєкті через `HabitsApiService` (wrapper над `/habits/`). Доступні операції:
+- `getHabits`
+- `createHabit`
+- `patchHabit` / `patchHabitTitle`
+- `archiveHabit`
+- `deleteHabit`
+- `toggleHabitCompletion`
+
+Це означає, що для `RoutineElement` не потрібно вигадувати новий базовий API-клієнт — потрібно інтегрувати вже наявний сервіс у Canvas flow.
+
+## Параметри рутини та поля модалок
+
+За контрактом `Habit` у коді є поля:
+- `id` (readonly)
+- `title`
+- `description`
+- `created_at`
+- `status`
+- `last_checked`
+- `is_due_today`
+- `weekly_completions`
+- `completions`
+
+### Які поля додавати в **Create Routine** modal (MVP)
+Обовʼязково:
+1. `title` (required, trim, не порожній)
+
+Опційно (але бажано одразу, якщо є місце в UI):
+2. `description` (optional)
+3. `status` (default = `Active`, можна заховати і не показувати в MVP)
+
+Не потрібно вводити вручну в create form:
+- `id`, `created_at`, `last_checked`, `is_due_today`, `weekly_completions`, `completions` — це серверні/обчислювані поля.
+
+### Які поля додавати в **Edit Routine** modal (MVP)
+Обовʼязково:
+1. `title`
+
+Опційно:
+2. `description`
+3. `status` (Active/Archived)
+
+Не редагувати в modal:
+- `id`, `created_at`, completion-масиви, `is_due_today`, `last_checked` (оновлюються через `toggleHabitCompletion`/backend логіку).
+
+### Чому саме такий мінімум
+- Поточний routines UI вже працює лише з назвою у create/edit flow.
+- Це узгоджено з існуючими методами сервісу (`createHabit(title)`, `patchHabitTitle(...)`).
+- Для Canvas MVP цього достатньо, а `description/status` можна відкрити наступною ітерацією без зламу API.
+
+## Вибрана форма для RoutineElement
+
+Обираємо форму: **коло (circle)** для `RoutineElement`.
+
+### Чому саме так
+- Це ваш явний продуктовий вибір: routine має бути візуально впізнаваною окремо від `Task/Story/Goal`.
+- Коло максимально відрізняється від поточних card-like елементів і одразу читається як окремий тип сутності.
+- У проєкті вже є базові приклади круглої геометрії (`Circle` shape), тому реалізація не є «з нуля».
+
+### Базові візуальні параметри (MVP)
+- `radius = 56` (діаметр `112`)
+- `fill = #ECFDF3`
+- `stroke = #22C55E`
+- `lineWidth = 2`
+- лейбл по центру: `Routine`/назва рутині (з truncation)
+
+### Технічні нотатки для circle
+- `contains(px, py)` має перевіряти відстань до центра (`dx*dx + dy*dy <= r*r`).
+- `getBoundaryPoint(angle)` для зʼєднань: `x = cx + r*cos(angle)`, `y = cy + r*sin(angle)`.
+- `getConnectionPoints()` для MVP: 4 точки (top/right/bottom/left), за потреби потім перейти на довільний кут.
+
+> Наслідок вибору: circle складніше по текстовому layout, ніж прямокутник. Для MVP краще ліміт на 1–2 рядки назви + tooltip/деталі у modal.
+
+## 1) Поточний стан (baseline)
+
+Зараз Canvas працює з трьома planning-елементами:
+- `GoalElement`
+- `StoryElement`
+- `TaskElement`
+
+Створення елемента відбувається через `AddElementCommand`, а UI-точка входу для ручного створення — контекстне меню (`ContextMenu`).
+
+## 2) Мінімальний план впровадження `RoutineElement`
+
+### Крок A. Створити клас елемента
+
+Створити файл `src/features/canvas/elements/RoutineElement.ts`:
+- наслідувати від `PlanningElement`
+- визначити `static width/height`
+- реалізувати `draw`, `contains`, `getBoundaryPoint`, `getConnectionPoints`, `clone`
+- додати рутинні поля (`backendId`, `uuid`, `title`, `status`), аналогічно `TaskElement`
+
+Рекомендація: для MVP тримати circle-геометрію простою (радіус + 4 connection points) і не ускладнювати полігональними варіантами.
+
+### Крок B. Розширити type-guards та місця, де перелічуються типи planning-елементів
+
+Оновити перевірки `instanceof` у місцях, де зараз жорстко перераховані `Task/Story/Goal`, зокрема:
+- `ContextMenu` (label, delete confirm key, actions)
+- менеджери та сервіси Canvas, які працюють з planning-елементами
+
+Практичне правило: всюди, де є патерн `element instanceof TaskElement || ...`, додати `RoutineElement` або винести у спільний guard.
+
+### Крок C. Додати створення Routine через Context Menu
+
+У `ContextMenu`:
+- в секції **Add item** додати пункт `Routine`
+- реалізувати `createRoutineAt(sceneX, sceneY)` через `historyService.execute(new AddElementCommand(...))`
+- додати людські label-и (`Routine`) у методи на кшталт `getElementLabel`, `getElementConfirmKey`
+
+### Крок D. Додати "existing routine" picker і сервіс
+
+За аналогією з `AddExistingTaskService`:
+1. Створити `AddExistingRoutineService`
+2. Створити `ExistingRoutinePicker`
+3. Зареєструвати новий drag kind у `existingPickerEvents`
+4. Підключити обробку drop у `UIManager`
+5. Додати secondary action у меню (`Find existing routine`)
+
+### Крок E. Гідратація/збереження позицій (API шар)
+
+Якщо routine має зберігатися в canvas layout як окремий тип:
+- додати маппери (аналогічно task/story/goal mapper)
+- оновити завантаження елементів у `CanvasApp`/репозиторій даних
+- оновити payload запису позицій у Canvas API
+
+Якщо routines поки не підтримуються бекендом Canvas layout:
+- дозволити лише runtime-додавання без persistence
+- явно позначити це feature-flag/коментарем, щоб уникнути «тихої» втрати даних
+
+### Крок F. Тести
+
+Мінімум:
+- unit для `RoutineElement` (`contains`, `clone`)
+- unit для `ContextMenu` (зʼявився пункт `Routine`)
+- unit для `AddExistingRoutineService` (add-or-focus логіка)
+- smoke-тест створення `Routine` через `AddElementCommand`
+
+## 3) Стисла інтеграційна карта (де правити в першу чергу)
+
+1. `src/features/canvas/elements/` — новий `RoutineElement`
+2. `src/features/canvas/ui/ContextMenu.ts` — пункти меню + create handler
+3. `src/features/canvas/ui/UIManager.ts` — existing-picker drag/drop
+4. `src/features/canvas/core/services/` — `AddExistingRoutineService`
+5. `src/features/canvas/ui/components/` — `ExistingRoutinePicker`
+6. `src/features/canvas/ui/events/existingPickerEvents.ts` — новий `kind`
+7. API маппінг/гідратація в Canvas data flow
+
+## 4) Рекомендована послідовність delivery
+
+1. `RoutineElement` + ручне створення з контекстного меню
+2. Підтримка selection/edit/delete/focus/highlight
+3. Existing routine picker (add/focus)
+4. Persistence (тільки після узгодження контракту API)
+5. Дотиснути тести
+
+## 5) Ризики
+
+- Пропустити одну з гілок `instanceof` і отримати «часткову» підтримку типу.
+- Додати UI створення без persistence і втрачати елементи після reload.
+- Невідповідність payload до бекенд-контракту для canvas positions.
+
+## 6) Definition of Done
+
+- `Routine` створюється з контекстного меню
+- `Routine` виділяється, рухається, видаляється, копіюється/вставляється
+- (опційно) додається як existing entity
+- (опційно) коректно зберігається/відновлюється після reload
+- тести зелені

--- a/src/features/canvas/CanvasApp.ts
+++ b/src/features/canvas/CanvasApp.ts
@@ -23,6 +23,7 @@ import { environment } from '../../config/environment.ts';
 import { TaskElement } from './elements/TaskElement.ts';
 import { StoryElement } from './elements/StoryElement.ts';
 import { GoalElement } from './elements/GoalElement.ts';
+import { RoutineElement } from './elements/RoutineElement.ts';
 import { isPlanningElement } from './elements/utils/typeGuards.ts';
 import { ElementStatus } from './elements/ElementStatus.ts';
 import {
@@ -50,6 +51,7 @@ import { authFlowService } from './ui/auth/authFlowService.ts';
 import { firstValueFrom, Observable, of, Subscription, throwError } from 'rxjs';
 import { catchError, finalize, map, switchMap } from 'rxjs/operators';
 import type { UiPriority } from '../../majom-wrapper/utils/priorityMapping.ts';
+import { HabitsApiService } from '../../majom-wrapper/data-access/habits-api-service.ts';
 
 type CanvasListUiItem = {
   id: string;
@@ -144,6 +146,7 @@ export class CanvasApp {
       new TasksApiService(http),
       new StoriesApiService(http),
       new GoalsApiService(http),
+      new HabitsApiService(http),
       new CanvasApiService(http),
       new CanvasRelationsApiService(http)
     );
@@ -535,7 +538,7 @@ export class CanvasApp {
 
   private handleElementDetailsEdited(event: Event): void {
     const customEvent = event as CustomEvent<{
-      element?: TaskElement | StoryElement | GoalElement;
+      element?: TaskElement | StoryElement | GoalElement | RoutineElement;
       patch?: Partial<{
         title: string;
         description: string;
@@ -555,13 +558,14 @@ export class CanvasApp {
 
   private handleCanvasPositionsDirty(event: Event): void {
     const customEvent = event as CustomEvent<{
-      elements?: Array<TaskElement | StoryElement | GoalElement>;
+      elements?: Array<TaskElement | StoryElement | GoalElement | RoutineElement>;
     }>;
     const elements = (customEvent.detail?.elements ?? []).filter(
-      (el): el is TaskElement | StoryElement | GoalElement =>
+      (el): el is TaskElement | StoryElement | GoalElement | RoutineElement =>
         el instanceof TaskElement ||
         el instanceof StoryElement ||
-        el instanceof GoalElement
+        el instanceof GoalElement ||
+        el instanceof RoutineElement
     );
     if (elements.length === 0) return;
     this.canvasDataService.markPositionsDirty(elements);
@@ -569,7 +573,7 @@ export class CanvasApp {
 
   private handleElementDeleteRequested(event: Event): void {
     const customEvent = event as CustomEvent<{
-      element?: TaskElement | StoryElement | GoalElement;
+      element?: TaskElement | StoryElement | GoalElement | RoutineElement;
     }>;
     const element = customEvent.detail?.element;
     if (!element) return;
@@ -708,7 +712,7 @@ export class CanvasApp {
     const elements = this.scene
       .getElements()
       .filter(isPlanningElement) as Array<
-      TaskElement | StoryElement | GoalElement
+      TaskElement | StoryElement | GoalElement | RoutineElement
     >;
     const saveSource: CanvasSaveSource = showNotifications
       ? 'manual'
@@ -727,7 +731,7 @@ export class CanvasApp {
     );
   }
   private saveLayoutPositions(
-    elements: Array<TaskElement | StoryElement | GoalElement>,
+    elements: Array<TaskElement | StoryElement | GoalElement | RoutineElement>,
     showNotifications: boolean
   ): Observable<boolean> {
     const positions: CanvasPositionWriteDTO[] = [];
@@ -739,8 +743,14 @@ export class CanvasApp {
           ? 'task'
           : el instanceof StoryElement
             ? 'story'
-            : 'goal';
-      const elementUuid = el.uuid;
+            : el instanceof GoalElement
+              ? 'goal'
+              : 'routine';
+      const elementUuid =
+        el.uuid ??
+        (el instanceof RoutineElement && Number.isFinite(el.backendId)
+          ? `habit-${el.backendId}`
+          : null);
       if (!elementUuid) {
         missingIds.push(String((el as any).id));
         return;
@@ -758,6 +768,12 @@ export class CanvasApp {
                 goalScale: el.scale,
                 focused: this.scene.isFocused(el),
                 highlighted: this.scene.isHighlighted(el),
+              }
+            : el instanceof RoutineElement
+            ? {
+                focused: this.scene.isFocused(el),
+                highlighted: this.scene.isHighlighted(el),
+                shape: 'circle',
               }
             : {
                 focused: this.scene.isFocused(el),
@@ -824,7 +840,15 @@ export class CanvasApp {
       }),
       switchMap(() =>
         this.canvasDataService
-          .updateCanvasRelations(this.scene.getConnections(), elements)
+          .updateCanvasRelations(
+            this.scene.getConnections(),
+            elements.filter(
+              (el): el is TaskElement | StoryElement | GoalElement =>
+                el instanceof TaskElement ||
+                el instanceof StoryElement ||
+                el instanceof GoalElement
+            )
+          )
           .pipe(
             catchError((err) => {
               this.queueUnsyncedDraft(relationsDraftId, 'relations', {
@@ -1006,7 +1030,7 @@ export class CanvasApp {
   }
 
   private applyFocusedElement(
-    elements: Array<TaskElement | StoryElement | GoalElement>,
+    elements: Array<TaskElement | StoryElement | GoalElement | RoutineElement>,
     focusedUuid: string | null
   ): void {
     const focusedElement =
@@ -1020,7 +1044,7 @@ export class CanvasApp {
   }
 
   private applyHighlightedElements(
-    elements: Array<TaskElement | StoryElement | GoalElement>,
+    elements: Array<TaskElement | StoryElement | GoalElement | RoutineElement>,
     highlightedUuids: string[]
   ): void {
     if (highlightedUuids.length === 0) {
@@ -1034,7 +1058,7 @@ export class CanvasApp {
             element.uuid === highlightedUuid || element.id === highlightedUuid
         )
       )
-      .filter((element): element is TaskElement | StoryElement | GoalElement =>
+      .filter((element): element is TaskElement | StoryElement | GoalElement | RoutineElement =>
         Boolean(element)
       )
       .map((element) => element.id);
@@ -1042,7 +1066,7 @@ export class CanvasApp {
   }
 
   private replacePlanningElements(
-    elements: Array<TaskElement | StoryElement | GoalElement>
+    elements: Array<TaskElement | StoryElement | GoalElement | RoutineElement>
   ): void {
     this.scene.replaceElements(isPlanningElement, elements);
   }
@@ -1444,7 +1468,7 @@ export class CanvasApp {
     const elements = this.scene
       .getElements()
       .filter(isPlanningElement) as Array<
-      TaskElement | StoryElement | GoalElement
+      TaskElement | StoryElement | GoalElement | RoutineElement
     >;
     if (
       !this.canvasDataService.hasRelationChanges(

--- a/src/features/canvas/core/eventBus.ts
+++ b/src/features/canvas/core/eventBus.ts
@@ -2,8 +2,9 @@ import { Subject } from 'rxjs';
 import type { TaskElement } from '../elements/TaskElement.ts';
 import type { StoryElement } from '../elements/StoryElement.ts';
 import type { GoalElement } from '../elements/GoalElement.ts';
+import type { RoutineElement } from '../elements/RoutineElement.ts';
 
 // Central bus for edit element events
 export const editElement$ = new Subject<
-  TaskElement | StoryElement | GoalElement
+  TaskElement | StoryElement | GoalElement | RoutineElement
 >();

--- a/src/features/canvas/core/managers/CanvasManager.ts
+++ b/src/features/canvas/core/managers/CanvasManager.ts
@@ -738,6 +738,13 @@ export class CanvasManager {
         this.ctx.beginPath();
         this.ctx.roundRect(x, y, width, height, 8);
         this.ctx.fill();
+      } else if (placeholder.elementType === 'routine') {
+        const centerX = x + width / 2;
+        const centerY = y + height / 2;
+        const radius = Math.min(width, height) / 2;
+        this.ctx.beginPath();
+        this.ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI);
+        this.ctx.fill();
       } else {
         const centerX = x + width / 2;
         const centerY = y + height / 2;
@@ -758,6 +765,11 @@ export class CanvasManager {
         this.ctx.roundRect(x, y, width, height, 24);
       } else if (placeholder.elementType === 'story') {
         this.ctx.roundRect(x, y, width, height, 8);
+      } else if (placeholder.elementType === 'routine') {
+        const centerX = x + width / 2;
+        const centerY = y + height / 2;
+        const radius = Math.min(width, height) / 2;
+        this.ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI);
       } else {
         const centerX = x + width / 2;
         const centerY = y + height / 2;

--- a/src/features/canvas/core/services/AddExistingRoutineService.ts
+++ b/src/features/canvas/core/services/AddExistingRoutineService.ts
@@ -1,0 +1,85 @@
+import { Scene } from '../scene/Scene.ts';
+import type { CanvasManager } from '../managers/CanvasManager.ts';
+import { RoutineElement } from '../../elements/RoutineElement.ts';
+import type { Habit } from '../../../../majom-wrapper/interfaces/index.ts';
+import { historyService } from './HistoryService.ts';
+import { mapStatus } from '../../../../majom-wrapper/utils/statusMapping.ts';
+import { AddElementCommand } from '../commands/AddElementCommand.ts';
+
+export class AddExistingRoutineService {
+  constructor(
+    private readonly scene: Scene,
+    private readonly canvasManager: CanvasManager
+  ) {}
+
+  public addOrFocus(routine: Habit, sceneX: number, sceneY: number): void {
+    const existing = this.getExistingRoutine(routine);
+    if (existing) {
+      this.scene.setSelected([existing]);
+      this.canvasManager.centerOnScenePoint(
+        existing.x + RoutineElement.radius,
+        existing.y + RoutineElement.radius
+      );
+      this.canvasManager.draw();
+      return;
+    }
+
+    const routineUuidRaw = (routine as Habit & { uuid?: unknown }).uuid;
+    const routineUuid =
+      typeof routineUuidRaw === 'string' && routineUuidRaw.trim().length > 0
+        ? routineUuidRaw
+        : `habit-${routine.id}`;
+
+    const routineElement = new RoutineElement({
+      id: routineUuid,
+      uuid: routineUuid,
+      backendId: routine.id,
+      title: routine.title,
+      description: routine.description,
+      status: mapStatus(routine.status),
+      x: sceneX - RoutineElement.radius,
+      y: sceneY - RoutineElement.radius,
+    });
+
+    historyService.execute(new AddElementCommand(this.scene, routineElement));
+    this.scene.setSelected([routineElement]);
+    this.canvasManager.draw();
+  }
+
+  public isOnCanvas(routine: Habit): boolean {
+    return this.getExistingRoutine(routine) !== null;
+  }
+
+  public focusExisting(routine: Habit): boolean {
+    const existing = this.getExistingRoutine(routine);
+    if (!existing) return false;
+    this.scene.setSelected([existing]);
+    this.canvasManager.centerOnScenePoint(
+      existing.x + RoutineElement.radius,
+      existing.y + RoutineElement.radius
+    );
+    this.canvasManager.draw();
+    return true;
+  }
+
+  public getExistingRoutine(routine: Habit): RoutineElement | null {
+    const sceneRoutines = this.scene
+      .getElements()
+      .filter(
+        (element): element is RoutineElement => element instanceof RoutineElement
+      );
+
+    const routineId = String(routine.id);
+    return (
+      sceneRoutines.find((existing) => {
+        if (
+          Number.isFinite(existing.backendId) &&
+          String(existing.backendId) === routineId
+        ) {
+          return true;
+        }
+        return existing.id === routineId;
+      }) ?? null
+    );
+  }
+}

--- a/src/features/canvas/core/services/SelectionContext.ts
+++ b/src/features/canvas/core/services/SelectionContext.ts
@@ -3,9 +3,14 @@ import type { ICanvasElement } from '../interfaces/canvasElement.ts';
 import { TaskElement } from '../../elements/TaskElement.ts';
 import { StoryElement } from '../../elements/StoryElement.ts';
 import { GoalElement } from '../../elements/GoalElement.ts';
+import { RoutineElement } from '../../elements/RoutineElement.ts';
 import { ElementStatus } from '../../elements/ElementStatus.ts';
 
-export type PlanningElement = TaskElement | StoryElement | GoalElement;
+export type PlanningElement =
+  | TaskElement
+  | StoryElement
+  | GoalElement
+  | RoutineElement;
 
 export class SelectionContext {
   public static getPlanningSelection(scene: Scene): PlanningElement[] {
@@ -22,7 +27,8 @@ export class SelectionContext {
     return (
       element instanceof TaskElement ||
       element instanceof StoryElement ||
-      element instanceof GoalElement
+      element instanceof GoalElement ||
+      element instanceof RoutineElement
     );
   }
 

--- a/src/features/canvas/core/types/canvasLoading.ts
+++ b/src/features/canvas/core/types/canvasLoading.ts
@@ -1,5 +1,5 @@
 export type CanvasLoadingPlaceholder = {
-  elementType: 'task' | 'story' | 'goal';
+  elementType: 'task' | 'story' | 'goal' | 'routine';
   elementUuid: string;
   x: number;
   y: number;

--- a/src/features/canvas/elements/RoutineElement.ts
+++ b/src/features/canvas/elements/RoutineElement.ts
@@ -1,0 +1,190 @@
+import { v4 } from 'uuid';
+import { PlanningElement } from './PlanningElement.ts';
+import type { ConnectionPoint } from '../core/interfaces/shape.ts';
+import { PanZoomManager } from '../core/managers/PanZoomManager.ts';
+import { ElementStatus } from './ElementStatus.ts';
+import {
+  FOCUS_COLOR,
+  HIGHLIGHT_COLOR,
+  SELECT_COLOR,
+  SHOW_ANIM_SCALE,
+} from '../core/constants.ts';
+
+const ROUTINE_FILL = '#ECFDF3';
+const ROUTINE_STROKE = '#22C55E';
+const ROUTINE_TEXT = '#14532D';
+
+export class RoutineElement extends PlanningElement {
+  public static radius = 56;
+
+  title: string;
+  status: ElementStatus = ElementStatus.Defined;
+
+  constructor({
+    id = v4(),
+    x = 0,
+    y = 0,
+    title = 'New Routine',
+    description = '',
+    selected = false,
+    status = ElementStatus.Defined,
+    backendId,
+    uuid,
+  }: {
+    id?: string;
+    x?: number;
+    y?: number;
+    title?: string;
+    description?: string;
+    selected?: boolean;
+    status?: ElementStatus;
+    backendId?: number;
+    uuid?: string;
+  }) {
+    const diameter = RoutineElement.radius * 2;
+    super({
+      id,
+      x,
+      y,
+      width: diameter,
+      height: diameter,
+      fillColor: ROUTINE_FILL,
+      lineWidth: 2,
+      title,
+      description,
+      backendId,
+      uuid,
+    });
+    this.zIndex = 2;
+    this.title = title;
+    this.selected = selected;
+    this.status = status;
+  }
+
+  draw(ctx: CanvasRenderingContext2D, panZoom: PanZoomManager): void {
+    const radius = RoutineElement.radius;
+    const centerX = this.x + radius;
+    const centerY = this.y + radius;
+
+    ctx.save();
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI);
+    ctx.fillStyle = ROUTINE_FILL;
+    ctx.fill();
+    ctx.strokeStyle = this.focused
+      ? FOCUS_COLOR
+      : this.highlighted
+        ? HIGHLIGHT_COLOR
+        : this.selected
+          ? SELECT_COLOR
+          : ROUTINE_STROKE;
+    ctx.lineWidth = 2 / panZoom.scale;
+    ctx.stroke();
+
+    if (panZoom.scale >= SHOW_ANIM_SCALE) {
+      ctx.beginPath();
+      ctx.arc(centerX, centerY, radius - 6 / panZoom.scale, 0, 2 * Math.PI);
+      ctx.strokeStyle = 'rgba(34, 197, 94, 0.22)';
+      ctx.lineWidth = 1 / panZoom.scale;
+      ctx.stroke();
+    }
+
+    ctx.fillStyle = ROUTINE_TEXT;
+    ctx.font = `${Math.max(11, 13 / panZoom.scale)}px Arial`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    const label = (this.title || 'Routine').trim();
+    const maxChars = 18;
+    const short = label.length > maxChars ? `${label.slice(0, maxChars - 1)}…` : label;
+    ctx.fillText(short, centerX, centerY, radius * 1.6);
+
+    const hoveredPort: ConnectionPoint | undefined = (this as any).hoveredPort;
+    if (this.selected || this.isHovered || hoveredPort) {
+      this.getConnectionPoints().forEach((point) => {
+        const isPortHovered = hoveredPort
+          ? point.x === hoveredPort.x && point.y === hoveredPort.y
+          : false;
+        if (!(this.selected || this.isHovered) && !isPortHovered) return;
+        ctx.beginPath();
+        ctx.arc(point.x, point.y, (isPortHovered ? 8 : 4) / panZoom.scale, 0, 2 * Math.PI);
+        ctx.fillStyle = isPortHovered ? SELECT_COLOR : '#ffffff';
+        ctx.fill();
+        ctx.strokeStyle = '#000000';
+        ctx.lineWidth = 1.5 / panZoom.scale;
+        ctx.stroke();
+      });
+    }
+
+    ctx.restore();
+  }
+
+  contains(px: number, py: number): boolean {
+    const radius = RoutineElement.radius;
+    const centerX = this.x + radius;
+    const centerY = this.y + radius;
+    const dx = px - centerX;
+    const dy = py - centerY;
+    return dx * dx + dy * dy <= radius * radius;
+  }
+
+  getBoundaryPoint(angle: number): { x: number; y: number } {
+    const radius = RoutineElement.radius;
+    const centerX = this.x + radius;
+    const centerY = this.y + radius;
+    return {
+      x: centerX + Math.cos(angle) * radius,
+      y: centerY + Math.sin(angle) * radius,
+    };
+  }
+
+  getConnectionPoints(): ConnectionPoint[] {
+    const radius = RoutineElement.radius;
+    const centerX = this.x + radius;
+    const centerY = this.y + radius;
+    return [
+      {
+        x: centerX,
+        y: centerY - radius,
+        angle: -Math.PI / 2,
+        isHovered: false,
+        direction: 'top',
+      },
+      {
+        x: centerX + radius,
+        y: centerY,
+        angle: 0,
+        isHovered: false,
+        direction: 'right',
+      },
+      {
+        x: centerX,
+        y: centerY + radius,
+        angle: Math.PI / 2,
+        isHovered: false,
+        direction: 'bottom',
+      },
+      {
+        x: centerX - radius,
+        y: centerY,
+        angle: Math.PI,
+        isHovered: false,
+        direction: 'left',
+      },
+    ];
+  }
+
+  clone(): PlanningElement {
+    return new RoutineElement({
+      x: this.x,
+      y: this.y,
+      title: this.title,
+      description: this.description,
+      status: this.status,
+      backendId: this.backendId,
+      uuid: this.uuid,
+    });
+  }
+
+
+}

--- a/src/features/canvas/elements/RoutineElement.ts
+++ b/src/features/canvas/elements/RoutineElement.ts
@@ -3,22 +3,27 @@ import { PlanningElement } from './PlanningElement.ts';
 import type { ConnectionPoint } from '../core/interfaces/shape.ts';
 import { PanZoomManager } from '../core/managers/PanZoomManager.ts';
 import { ElementStatus } from './ElementStatus.ts';
+import { editElement$ } from '../core/eventBus.ts';
 import {
   FOCUS_COLOR,
   HIGHLIGHT_COLOR,
+  FONT_FAMILY,
+  TITLE_FONT_SIZE,
   SELECT_COLOR,
-  SHOW_ANIM_SCALE,
 } from '../core/constants.ts';
+import { TextRenderer } from '../utils/TextRenderer.ts';
+import { normalizeRoutineStatus } from './routineStatus.ts';
+import { routineStyles } from './styles/routineStyles.ts';
 
-const ROUTINE_FILL = '#ECFDF3';
-const ROUTINE_STROKE = '#22C55E';
-const ROUTINE_TEXT = '#14532D';
+const ROUTINE_TEXT = '#000000';
 
 export class RoutineElement extends PlanningElement {
-  public static radius = 56;
+  public static radius = 92;
 
   title: string;
   status: ElementStatus = ElementStatus.Defined;
+  public borderColor: string =
+    routineStyles[ElementStatus.InProgress].borderColor;
 
   constructor({
     id = v4(),
@@ -27,7 +32,7 @@ export class RoutineElement extends PlanningElement {
     title = 'New Routine',
     description = '',
     selected = false,
-    status = ElementStatus.Defined,
+    status = ElementStatus.InProgress,
     backendId,
     uuid,
   }: {
@@ -42,13 +47,15 @@ export class RoutineElement extends PlanningElement {
     uuid?: string;
   }) {
     const diameter = RoutineElement.radius * 2;
+    const normalizedStatus = normalizeRoutineStatus(status);
+    const style = routineStyles[normalizedStatus];
     super({
       id,
       x,
       y,
       width: diameter,
       height: diameter,
-      fillColor: ROUTINE_FILL,
+      fillColor: style.fillColor,
       lineWidth: 2,
       title,
       description,
@@ -58,7 +65,8 @@ export class RoutineElement extends PlanningElement {
     this.zIndex = 2;
     this.title = title;
     this.selected = selected;
-    this.status = status;
+    this.status = normalizedStatus;
+    this.borderColor = style.borderColor;
   }
 
   draw(ctx: CanvasRenderingContext2D, panZoom: PanZoomManager): void {
@@ -70,34 +78,41 @@ export class RoutineElement extends PlanningElement {
     ctx.setLineDash([]);
     ctx.beginPath();
     ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI);
-    ctx.fillStyle = ROUTINE_FILL;
+    const style = routineStyles[this.status];
+    this.fillColor = style.fillColor;
+    ctx.fillStyle = style.fillColor;
     ctx.fill();
+    this.borderColor = this.focused
+      ? FOCUS_COLOR
+      : this.highlighted
+        ? HIGHLIGHT_COLOR
+        : this.selected
+          ? SELECT_COLOR
+          : style.borderColor;
     ctx.strokeStyle = this.focused
       ? FOCUS_COLOR
       : this.highlighted
         ? HIGHLIGHT_COLOR
         : this.selected
           ? SELECT_COLOR
-          : ROUTINE_STROKE;
+          : style.borderColor;
     ctx.lineWidth = 2 / panZoom.scale;
     ctx.stroke();
 
-    if (panZoom.scale >= SHOW_ANIM_SCALE) {
-      ctx.beginPath();
-      ctx.arc(centerX, centerY, radius - 6 / panZoom.scale, 0, 2 * Math.PI);
-      ctx.strokeStyle = 'rgba(34, 197, 94, 0.22)';
-      ctx.lineWidth = 1 / panZoom.scale;
-      ctx.stroke();
-    }
-
     ctx.fillStyle = ROUTINE_TEXT;
-    ctx.font = `${Math.max(11, 13 / panZoom.scale)}px Arial`;
+    const fontSize = Math.max(12, TITLE_FONT_SIZE / panZoom.scale);
+    ctx.font = `${fontSize}px ${FONT_FAMILY}`;
+    const label = (this.title || 'Routine').trim();
+    const maxTextWidth = radius * 1.45;
+    const lines = TextRenderer.wrapText(ctx, label, maxTextWidth, 2);
+    const lineHeight = fontSize * 1.25;
+    const blockHeight = lines.length > 0 ? (lines.length - 1) * lineHeight : 0;
+    const startY = centerY - blockHeight / 2;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    const label = (this.title || 'Routine').trim();
-    const maxChars = 18;
-    const short = label.length > maxChars ? `${label.slice(0, maxChars - 1)}…` : label;
-    ctx.fillText(short, centerX, centerY, radius * 1.6);
+    lines.forEach((line, index) => {
+      ctx.fillText(line, centerX, startY + index * lineHeight);
+    });
 
     const hoveredPort: ConnectionPoint | undefined = (this as any).hoveredPort;
     if (this.selected || this.isHovered || hoveredPort) {
@@ -107,7 +122,13 @@ export class RoutineElement extends PlanningElement {
           : false;
         if (!(this.selected || this.isHovered) && !isPortHovered) return;
         ctx.beginPath();
-        ctx.arc(point.x, point.y, (isPortHovered ? 8 : 4) / panZoom.scale, 0, 2 * Math.PI);
+        ctx.arc(
+          point.x,
+          point.y,
+          (isPortHovered ? 8 : 4) / panZoom.scale,
+          0,
+          2 * Math.PI
+        );
         ctx.fillStyle = isPortHovered ? SELECT_COLOR : '#ffffff';
         ctx.fill();
         ctx.strokeStyle = '#000000';
@@ -186,5 +207,7 @@ export class RoutineElement extends PlanningElement {
     });
   }
 
-
+  public onDoubleClick(): void {
+    editElement$.next(this);
+  }
 }

--- a/src/features/canvas/elements/routineStatus.test.ts
+++ b/src/features/canvas/elements/routineStatus.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { Status } from '../../../majom-wrapper/interfaces/index.ts';
+import { ElementStatus } from './ElementStatus.ts';
+import {
+  getRoutineStatusIcon,
+  getRoutineStatusLabel,
+  mapRoutineStatusToBackend,
+  normalizeRoutineStatus,
+} from './routineStatus.ts';
+
+describe('routineStatus', () => {
+  it('normalizes legacy routine statuses to active', () => {
+    expect(normalizeRoutineStatus(ElementStatus.Defined)).toBe(
+      ElementStatus.InProgress
+    );
+    expect(normalizeRoutineStatus(ElementStatus.Pending)).toBe(
+      ElementStatus.InProgress
+    );
+  });
+
+  it('keeps archived routines mapped to done', () => {
+    expect(normalizeRoutineStatus(ElementStatus.Done)).toBe(ElementStatus.Done);
+    expect(getRoutineStatusLabel(ElementStatus.Done)).toBe('Archived');
+    expect(getRoutineStatusIcon(ElementStatus.Done)).toBe('archive-box');
+    expect(mapRoutineStatusToBackend(ElementStatus.Done)).toBe(Status.Archived);
+  });
+
+  it('maps active routines to in-progress semantics', () => {
+    expect(getRoutineStatusLabel(ElementStatus.InProgress)).toBe('Active');
+    expect(getRoutineStatusIcon(ElementStatus.InProgress)).toBe('arrow-path');
+    expect(mapRoutineStatusToBackend(ElementStatus.InProgress)).toBe(
+      Status.Active
+    );
+  });
+});

--- a/src/features/canvas/elements/routineStatus.ts
+++ b/src/features/canvas/elements/routineStatus.ts
@@ -1,0 +1,44 @@
+import { Status } from '../../../majom-wrapper/interfaces/index.ts';
+import { ElementStatus } from './ElementStatus.ts';
+import type { IconName } from '../ui/icons.ts';
+
+export const ROUTINE_STATUS_ORDER: readonly ElementStatus[] = [
+  ElementStatus.InProgress,
+  ElementStatus.Done,
+];
+
+export const ROUTINE_STATUS_OPTIONS: Array<{
+  value: ElementStatus;
+  label: string;
+}> = ROUTINE_STATUS_ORDER.map((status) => ({
+  value: status,
+  label: getRoutineStatusLabel(status),
+}));
+
+export function normalizeRoutineStatus(status: ElementStatus): ElementStatus {
+  return status === ElementStatus.Done
+    ? ElementStatus.Done
+    : ElementStatus.InProgress;
+}
+
+export function getRoutineStatusLabel(status: ElementStatus): string {
+  return status === ElementStatus.Done ? 'Archived' : 'Active';
+}
+
+export function getRoutineStatusIcon(status: ElementStatus): IconName {
+  return status === ElementStatus.Done ? 'archive-box' : 'arrow-path';
+}
+
+export function getRoutineStatusIconToneClass(status: ElementStatus): string {
+  return status === ElementStatus.Done ? '!text-slate-500' : '!text-blue-600';
+}
+
+export function getRoutineStatusChipPalette(status: ElementStatus): string {
+  return status === ElementStatus.Done
+    ? 'border-slate-200 bg-slate-100 text-slate-600'
+    : 'border-blue-200 bg-blue-100 text-blue-700';
+}
+
+export function mapRoutineStatusToBackend(status: ElementStatus): Status {
+  return status === ElementStatus.Done ? Status.Archived : Status.Active;
+}

--- a/src/features/canvas/elements/styles/routineStyles.ts
+++ b/src/features/canvas/elements/styles/routineStyles.ts
@@ -1,0 +1,31 @@
+import {
+  GOAL_STATUS_DEFINED_FILL,
+  GOAL_STATUS_IN_PROGRESS_FILL,
+  STORY_STATUS_DEFINED_BORDER,
+  STORY_STATUS_IN_PROGRESS_BORDER,
+} from '../constants.ts';
+import { ElementStatus } from '../ElementStatus.ts';
+
+export interface RoutineStyle {
+  fillColor: string;
+  borderColor: string;
+}
+
+export const routineStyles: Record<ElementStatus, RoutineStyle> = {
+  done: {
+    fillColor: GOAL_STATUS_DEFINED_FILL,
+    borderColor: STORY_STATUS_DEFINED_BORDER,
+  },
+  'in-progress': {
+    fillColor: GOAL_STATUS_IN_PROGRESS_FILL,
+    borderColor: STORY_STATUS_IN_PROGRESS_BORDER,
+  },
+  pending: {
+    fillColor: GOAL_STATUS_DEFINED_FILL,
+    borderColor: STORY_STATUS_DEFINED_BORDER,
+  },
+  defined: {
+    fillColor: GOAL_STATUS_DEFINED_FILL,
+    borderColor: STORY_STATUS_DEFINED_BORDER,
+  },
+};

--- a/src/features/canvas/mappers/routine-mapper.ts
+++ b/src/features/canvas/mappers/routine-mapper.ts
@@ -1,0 +1,36 @@
+import type { CanvasPositionReadDTO } from '../../../majom-wrapper/data-access/canvas-position-dto.ts';
+import type { Habit } from '../../../majom-wrapper/interfaces/index.ts';
+import { mapStatus } from '../../../majom-wrapper/utils/statusMapping.ts';
+import { RoutineElement } from '../elements/RoutineElement.ts';
+
+const DEFAULT_X = 0;
+const DEFAULT_Y = 0;
+
+function getHabitUuid(habit: Habit): string {
+  const rawUuid = (habit as Habit & { uuid?: unknown }).uuid;
+  if (typeof rawUuid === 'string' && rawUuid.trim().length > 0) {
+    return rawUuid;
+  }
+  return `habit-${habit.id}`;
+}
+
+export function mapRoutine(
+  dto: Habit,
+  layout: CanvasPositionReadDTO[]
+): RoutineElement {
+  const routineUuid = getHabitUuid(dto);
+  const pos = layout.find(
+    (entry) =>
+      entry.element_type === 'routine' && entry.element_uuid === routineUuid
+  );
+  return new RoutineElement({
+    id: routineUuid,
+    uuid: routineUuid,
+    backendId: dto.id,
+    x: pos?.x ?? DEFAULT_X,
+    y: pos?.y ?? DEFAULT_Y,
+    title: dto.title,
+    description: dto.description,
+    status: mapStatus(dto.status),
+  });
+}

--- a/src/features/canvas/ui/ContextMenu.ts
+++ b/src/features/canvas/ui/ContextMenu.ts
@@ -41,6 +41,12 @@ import {
   STATUS_ICON_TONE_CLASS,
   STATUS_ORDER,
 } from './statusPresentation.ts';
+import {
+  getRoutineStatusIcon,
+  getRoutineStatusIconToneClass,
+  getRoutineStatusLabel,
+  ROUTINE_STATUS_ORDER,
+} from '../elements/routineStatus.ts';
 
 type ContextMenuDetail = {
   element: ICanvasElement | null;
@@ -263,6 +269,10 @@ export class ContextMenu {
             secondaryIcon: 'magnifying-glass',
             secondaryLabel: 'Find existing task',
           },
+        ],
+      });
+      sections.push({
+        items: [
           {
             label: 'Routine',
             action: () => this.createRoutineAt(sceneX, sceneY),
@@ -385,13 +395,21 @@ export class ContextMenu {
         | StoryElement
         | GoalElement
         | RoutineElement;
+      const isRoutine = planningElement instanceof RoutineElement;
+      const statusOrder = isRoutine ? ROUTINE_STATUS_ORDER : STATUS_ORDER;
       sections.push({
         title: 'Set status',
-        items: STATUS_ORDER.map((status) => {
+        items: statusOrder.map((status) => {
           const isCurrent = planningElement.status === status;
           return {
-            label: getStatusLabel(status),
-            leading: this.createStatusIcon(status),
+            label: isRoutine
+              ? getRoutineStatusLabel(status)
+              : getStatusLabel(status),
+            leading: this.createStatusIcon(
+              status,
+              isRoutine ? getRoutineStatusIcon(status) : undefined,
+              isRoutine ? getRoutineStatusIconToneClass(status) : undefined
+            ),
             trailing: isCurrent ? this.createActiveStatusCheck() : null,
             variant: isCurrent ? 'selected' : 'default',
             action: () => {
@@ -516,14 +534,18 @@ export class ContextMenu {
     return wrap;
   }
 
-  private createStatusIcon(status: ElementStatus): HTMLSpanElement {
+  private createStatusIcon(
+    status: ElementStatus,
+    iconName: IconName = STATUS_ICON_MAP[status],
+    toneClass: string = STATUS_ICON_TONE_CLASS[status]
+  ): HTMLSpanElement {
     const wrap = document.createElement('span');
     wrap.className = 'inline-flex items-center justify-center';
-    const icon = createIcon(STATUS_ICON_MAP[status], {
+    const icon = createIcon(iconName, {
       size: 14,
       strokeWidth: 1.7,
     });
-    icon.classList.add('shrink-0', STATUS_ICON_TONE_CLASS[status]);
+    icon.classList.add('shrink-0', toneClass);
     icon.setAttribute('aria-hidden', 'true');
     wrap.appendChild(icon);
     return wrap;

--- a/src/features/canvas/ui/ContextMenu.ts
+++ b/src/features/canvas/ui/ContextMenu.ts
@@ -13,6 +13,7 @@ import type { ICanvasElement } from '../core/interfaces/canvasElement.ts';
 import { TaskElement } from '../elements/TaskElement.ts';
 import { StoryElement } from '../elements/StoryElement.ts';
 import { GoalElement } from '../elements/GoalElement.ts';
+import { RoutineElement } from '../elements/RoutineElement.ts';
 import { StoryLayoutService } from '../core/services/StoryLayoutService.ts';
 import { positionFixedElement } from './overlayPosition.ts';
 import { BulkActionsController } from '../core/services/BulkActionsController.ts';
@@ -21,10 +22,12 @@ import { addTaskToStory } from './storyTaskActions.ts';
 import { ExistingTaskPicker } from './components/ExistingTaskPicker.ts';
 import { ExistingGoalPicker } from './components/ExistingGoalPicker.ts';
 import { ExistingStoryPicker } from './components/ExistingStoryPicker.ts';
+import { ExistingRoutinePicker } from './components/ExistingRoutinePicker.ts';
 import { createMenuBadge } from './components/MenuBadge.ts';
 import { AddExistingTaskService } from '../core/services/AddExistingTaskService.ts';
 import { AddExistingGoalService } from '../core/services/AddExistingGoalService.ts';
 import { AddExistingStoryService } from '../core/services/AddExistingStoryService.ts';
+import { AddExistingRoutineService } from '../core/services/AddExistingRoutineService.ts';
 import {
   createDivider,
   createDropdownItem,
@@ -101,9 +104,11 @@ export class ContextMenu {
     private existingTaskPicker: ExistingTaskPicker,
     private existingGoalPicker: ExistingGoalPicker,
     private existingStoryPicker: ExistingStoryPicker,
+    private existingRoutinePicker: ExistingRoutinePicker,
     private addExistingTaskService: AddExistingTaskService,
     private addExistingGoalService: AddExistingGoalService,
-    private addExistingStoryService: AddExistingStoryService
+    private addExistingStoryService: AddExistingStoryService,
+    private addExistingRoutineService: AddExistingRoutineService
   ) {
     this.bulkActions = new BulkActionsController(scene);
     this.menu = document.createElement('div');
@@ -152,6 +157,7 @@ export class ContextMenu {
     this.existingTaskPicker.close();
     this.existingGoalPicker.close();
     this.existingStoryPicker.close();
+    this.existingRoutinePicker.close();
     this.closeSubmenu();
     this.submenu.removeEventListener('keydown', this.onSubmenuKeyDown);
     this.submenu.remove();
@@ -257,6 +263,13 @@ export class ContextMenu {
             secondaryIcon: 'magnifying-glass',
             secondaryLabel: 'Find existing task',
           },
+          {
+            label: 'Routine',
+            action: () => this.createRoutineAt(sceneX, sceneY),
+            secondaryAction: () => this.openExistingRoutinePicker(sceneX, sceneY),
+            secondaryIcon: 'magnifying-glass',
+            secondaryLabel: 'Find existing routine',
+          },
         ],
       });
       return sections;
@@ -265,7 +278,8 @@ export class ContextMenu {
     const isPlanningElement =
       element instanceof TaskElement ||
       element instanceof StoryElement ||
-      element instanceof GoalElement;
+      element instanceof GoalElement ||
+      element instanceof RoutineElement;
     const confirmKey = this.getElementConfirmKey(element);
     const isConfirming = this.isConfirmingDelete(confirmKey);
     const elementLabel = this.getElementLabel(element);
@@ -300,6 +314,7 @@ export class ContextMenu {
       if (el instanceof TaskElement) return 'Task';
       if (el instanceof StoryElement) return 'Story';
       if (el instanceof GoalElement) return 'Goal';
+      if (el instanceof RoutineElement) return 'Routine';
       return undefined;
     };
 
@@ -329,7 +344,8 @@ export class ContextMenu {
       const planningElement = element as
         | TaskElement
         | StoryElement
-        | GoalElement;
+        | GoalElement
+        | RoutineElement;
       const isFocused = this.scene.isFocused(planningElement);
       const isHighlighted = this.scene.isHighlighted(planningElement);
       sections.push({
@@ -367,7 +383,8 @@ export class ContextMenu {
       const planningElement = element as
         | TaskElement
         | StoryElement
-        | GoalElement;
+        | GoalElement
+        | RoutineElement;
       sections.push({
         title: 'Set status',
         items: STATUS_ORDER.map((status) => {
@@ -769,6 +786,7 @@ export class ContextMenu {
     if (element instanceof TaskElement) return `task:${element.id}`;
     if (element instanceof StoryElement) return `story:${element.id}`;
     if (element instanceof GoalElement) return `goal:${element.id}`;
+    if (element instanceof RoutineElement) return `routine:${element.id}`;
     return null;
   }
 
@@ -776,6 +794,7 @@ export class ContextMenu {
     if (element instanceof TaskElement) return 'Task';
     if (element instanceof StoryElement) return 'Story';
     if (element instanceof GoalElement) return 'Goal';
+    if (element instanceof RoutineElement) return 'Routine';
     return 'element';
   }
 
@@ -813,6 +832,16 @@ export class ContextMenu {
     });
     historyService.execute(new AddElementCommand(this.scene, story));
     this.scene.setSelected([story]);
+    this.canvasManager.draw();
+  }
+
+  private createRoutineAt(sceneX: number, sceneY: number): void {
+    const routine = new RoutineElement({
+      x: sceneX - RoutineElement.radius,
+      y: sceneY - RoutineElement.radius,
+    });
+    historyService.execute(new AddElementCommand(this.scene, routine));
+    this.scene.setSelected([routine]);
     this.canvasManager.draw();
   }
 
@@ -855,6 +884,17 @@ export class ContextMenu {
       isOnCanvas: (story) => this.addExistingStoryService.isOnCanvas(story),
       onPick: (story, storyX, storyY) => {
         this.addExistingStoryService.addOrFocus(story, storyX, storyY);
+      },
+    });
+  }
+
+  private openExistingRoutinePicker(sceneX: number, sceneY: number): void {
+    this.existingRoutinePicker.open({
+      sceneX,
+      sceneY,
+      isOnCanvas: (routine) => this.addExistingRoutineService.isOnCanvas(routine),
+      onPick: (routine, routineX, routineY) => {
+        this.addExistingRoutineService.addOrFocus(routine, routineX, routineY);
       },
     });
   }

--- a/src/features/canvas/ui/SelectionActionMenu.ts
+++ b/src/features/canvas/ui/SelectionActionMenu.ts
@@ -5,6 +5,7 @@ import type { ICanvasElement } from '../core/interfaces/canvasElement.ts';
 import { TaskElement } from '../elements/TaskElement.ts';
 import { StoryElement } from '../elements/StoryElement.ts';
 import { GoalElement } from '../elements/GoalElement.ts';
+import { RoutineElement } from '../elements/RoutineElement.ts';
 import { historyService } from '../core/services/HistoryService.ts';
 import { StoryLayoutService } from '../core/services/StoryLayoutService.ts';
 import {
@@ -252,6 +253,8 @@ export class SelectionActionMenu {
   private buildActionNodes(): ActionNode[] {
     const isSingle = (context: ActionContext): boolean => !context.isMulti;
     const isMulti = (context: ActionContext): boolean => context.isMulti;
+    const hasCompatibleStatuses = (context: ActionContext): boolean =>
+      !this.hasMixedRoutineStatuses(context.elements);
     const isStory = (context: ActionContext): boolean =>
       context.primary instanceof StoryElement;
     const isStoryOrGoal = (context: ActionContext): boolean =>
@@ -263,12 +266,13 @@ export class SelectionActionMenu {
         id: 'status',
         title: 'Change status',
         variant: 'status',
+        isVisible: hasCompatibleStatuses,
         onClick: () => {},
       },
       {
         kind: 'divider',
         id: 'divider-status',
-        isVisible: isMulti,
+        isVisible: (context) => isMulti(context) && hasCompatibleStatuses(context),
       },
       {
         kind: 'action',
@@ -503,8 +507,18 @@ export class SelectionActionMenu {
 
   private updateStatusSelector(elements: PlanningElement[]): void {
     if (!this.statusSelector || elements.length === 0) return;
+    const routineOnly = elements.every((element) => element instanceof RoutineElement);
+    this.statusSelector.setMode(routineOnly ? 'routine' : 'default');
     const status = SelectionContext.getMixedStatus(elements);
     this.statusSelector.setState(status ?? null);
+  }
+
+  private hasMixedRoutineStatuses(elements: PlanningElement[]): boolean {
+    const hasRoutine = elements.some((element) => element instanceof RoutineElement);
+    const hasNonRoutine = elements.some(
+      (element) => !(element instanceof RoutineElement)
+    );
+    return hasRoutine && hasNonRoutine;
   }
 
   private updateDeleteConfirmation(elements: PlanningElement[]): void {
@@ -567,6 +581,7 @@ export class SelectionActionMenu {
     if (element instanceof TaskElement) return `task:${element.id}`;
     if (element instanceof StoryElement) return `story:${element.id}`;
     if (element instanceof GoalElement) return `goal:${element.id}`;
+    if (element instanceof RoutineElement) return `routine:${element.id}`;
     return null;
   }
 

--- a/src/features/canvas/ui/UIManager.ts
+++ b/src/features/canvas/ui/UIManager.ts
@@ -15,16 +15,19 @@ import { BulkActionsController } from '../core/services/BulkActionsController.ts
 import { ExistingTaskPicker } from './components/ExistingTaskPicker.ts';
 import { ExistingGoalPicker } from './components/ExistingGoalPicker.ts';
 import { ExistingStoryPicker } from './components/ExistingStoryPicker.ts';
+import { ExistingRoutinePicker } from './components/ExistingRoutinePicker.ts';
 import { environment } from '../../../config/environment.ts';
 import { HttpInterceptorClient } from '../../../majom-wrapper/data-access/http-interceptor.ts';
 import { TasksApiService } from '../../../majom-wrapper/data-access/tasks-api-service.ts';
 import { GoalsApiService } from '../../../majom-wrapper/data-access/goals-api-service.ts';
 import { StoriesApiService } from '../../../majom-wrapper/data-access/stories-api-service.ts';
+import { HabitsApiService } from '../../../majom-wrapper/data-access/habits-api-service.ts';
 import { map } from 'rxjs/operators';
 import type { Subscription } from 'rxjs';
 import { AddExistingTaskService } from '../core/services/AddExistingTaskService.ts';
 import { AddExistingGoalService } from '../core/services/AddExistingGoalService.ts';
 import { AddExistingStoryService } from '../core/services/AddExistingStoryService.ts';
+import { AddExistingRoutineService } from '../core/services/AddExistingRoutineService.ts';
 import { AuthService } from '../../../majom-wrapper/data-access/auth-service.ts';
 import { UserApiService } from '../../../majom-wrapper/data-access/user-api-service.ts';
 import { CanvasMenu } from './components/CanvasMenu.ts';
@@ -46,6 +49,7 @@ export class UIManager {
   private readonly addExistingTaskService: AddExistingTaskService;
   private readonly addExistingGoalService: AddExistingGoalService;
   private readonly addExistingStoryService: AddExistingStoryService;
+  private readonly addExistingRoutineService: AddExistingRoutineService;
   private existingPickerDragStateHandler: ((event: Event) => void) | null =
     null;
   private existingPickerDragMoveHandler: ((event: Event) => void) | null = null;
@@ -82,6 +86,7 @@ export class UIManager {
     const tasksApi = new TasksApiService(http);
     const goalsApi = new GoalsApiService(http);
     const storiesApi = new StoriesApiService(http);
+    const habitsApi = new HabitsApiService(http);
     const userApi = new UserApiService(http);
     const canvasMenu = new CanvasMenu(this.authService, userApi, {
       containerClassName: 'relative z-30 flex items-center',
@@ -102,6 +107,10 @@ export class UIManager {
       this.canvasManager
     );
     this.addExistingStoryService = new AddExistingStoryService(
+      this.scene,
+      this.canvasManager
+    );
+    this.addExistingRoutineService = new AddExistingRoutineService(
       this.scene,
       this.canvasManager
     );
@@ -148,15 +157,38 @@ export class UIManager {
             }))
           )
     );
+    const existingRoutinePicker = new ExistingRoutinePicker((term, page, pageSize) =>
+      habitsApi.getHabits().pipe(
+        map((items) => {
+          const normalizedTerm = term.trim().toLowerCase();
+          const filtered = normalizedTerm
+            ? items.filter((routine) =>
+                [routine.title, routine.description]
+                  .join(' ')
+                  .toLowerCase()
+                  .includes(normalizedTerm)
+              )
+            : items;
+          const start = (page - 1) * pageSize;
+          const pageItems = filtered.slice(start, start + pageSize);
+          return {
+            items: pageItems,
+            hasMore: start + pageSize < filtered.length,
+          };
+        })
+      )
+    );
     const contextMenu = new ContextMenu(
       this.scene,
       this.canvasManager,
       existingTaskPicker,
       existingGoalPicker,
       existingStoryPicker,
+      existingRoutinePicker,
       this.addExistingTaskService,
       this.addExistingGoalService,
-      this.addExistingStoryService
+      this.addExistingStoryService,
+      this.addExistingRoutineService
     );
     const bulkActions = new BulkActionsController(this.scene);
     const selectionActions = new SelectionActionMenu(
@@ -323,7 +355,8 @@ export class UIManager {
     const x = (clientX - rect.left + panZoom.scrollX) / panZoom.scale;
     const y = (clientY - rect.top + panZoom.scrollY) / panZoom.scale;
 
-    const existingItem = payload?.item ?? payload?.goal ?? payload?.story;
+    const existingItem =
+      payload?.item ?? payload?.goal ?? payload?.story ?? payload?.routine;
     if (payload?.kind === 'existing-goal' && existingItem) {
       this.addExistingGoalService.addOrFocus(existingItem, x, y);
       emitExistingPickerDropCompleted('existing-goal');
@@ -337,6 +370,11 @@ export class UIManager {
     if (payload?.kind === 'existing-story' && existingItem) {
       this.addExistingStoryService.addOrFocus(existingItem, x, y);
       emitExistingPickerDropCompleted('existing-story');
+      return;
+    }
+    if (payload?.kind === 'existing-routine' && existingItem) {
+      this.addExistingRoutineService.addOrFocus(existingItem, x, y);
+      emitExistingPickerDropCompleted('existing-routine');
       return;
     }
   }

--- a/src/features/canvas/ui/components/EditElementModal.ts
+++ b/src/features/canvas/ui/components/EditElementModal.ts
@@ -1,6 +1,7 @@
 import { TaskElement } from '../../elements/TaskElement.ts';
 import { StoryElement } from '../../elements/StoryElement.ts';
 import { GoalElement, GoalScale } from '../../elements/GoalElement.ts';
+import { RoutineElement } from '../../elements/RoutineElement.ts';
 import { Scene } from '../../core/scene/Scene.ts';
 import { ComponentFactory } from '../../../../ui-lib/src/core/ComponentFactory.ts';
 import {
@@ -23,6 +24,10 @@ import {
   ElementStatus,
 } from '../../elements/ElementStatus.ts';
 import type { UiPriority } from '../../../../majom-wrapper/utils/priorityMapping.ts';
+import {
+  ROUTINE_STATUS_OPTIONS,
+  normalizeRoutineStatus,
+} from '../../elements/routineStatus.ts';
 
 type DescriptionMode = 'view' | 'edit';
 
@@ -58,7 +63,7 @@ export class EditElementModal {
   private scaleControl: SegmentedControl<GoalScale> | null = null;
 
   constructor(
-    private element: TaskElement | StoryElement | GoalElement,
+    private element: TaskElement | StoryElement | GoalElement | RoutineElement,
     private scene: Scene
   ) {}
 
@@ -70,7 +75,9 @@ export class EditElementModal {
         ? 'Task'
         : this.element instanceof StoryElement
           ? 'Story'
-          : 'Goal';
+          : this.element instanceof GoalElement
+            ? 'Goal'
+            : 'Routine';
     const formatDateInputValue = (value: Date | null | undefined): string => {
       if (!value || !(value instanceof Date) || Number.isNaN(value.getTime())) {
         return '';
@@ -83,16 +90,22 @@ export class EditElementModal {
       return Number.isNaN(parsed.getTime()) ? null : parsed;
     };
     // Local temp state
-    const originalTitle = this.element.title;
-    const originalDescription = this.element.description;
-    const originalStatus: ElementStatus = this.element.status;
-    const originalPriority = this.element.priority;
+    const routineElement =
+      this.element instanceof RoutineElement ? this.element : null;
+    const isRoutine = routineElement !== null;
     const taskElement =
       this.element instanceof TaskElement ? this.element : null;
     const isTask = taskElement !== null;
     const goalElement =
       this.element instanceof GoalElement ? this.element : null;
     const isGoal = goalElement !== null;
+    const priorityElement = isRoutine ? null : this.element;
+    const originalTitle = this.element.title;
+    const originalDescription = this.element.description;
+    const originalStatus: ElementStatus = isRoutine
+      ? normalizeRoutineStatus(this.element.status)
+      : this.element.status;
+    const originalPriority = priorityElement?.priority ?? 'low';
     const originalScale: GoalScale | null = goalElement
       ? goalElement.scale
       : null;
@@ -113,7 +126,7 @@ export class EditElementModal {
       if (normalizedTitle !== originalTitle) return true;
       if (tempDescription !== originalDescription) return true;
       if (tempStatus !== originalStatus) return true;
-      if (tempPriority !== originalPriority) return true;
+      if (!isRoutine && tempPriority !== originalPriority) return true;
       if (isTask && tempDueDateValue !== originalDueDateValue) return true;
       if (isGoal && originalScale !== tempScale) return true;
       return false;
@@ -193,10 +206,12 @@ export class EditElementModal {
     const statusField = createField({ label: 'Status' });
     const statusSelect = ComponentFactory.createSelect({
       variant: 'default',
-      items: ELEMENT_STATUS_OPTIONS,
+      items: isRoutine ? ROUTINE_STATUS_OPTIONS : ELEMENT_STATUS_OPTIONS,
       selectedValue: tempStatus,
       onChange: (v: string) => {
-        tempStatus = v as ElementStatus;
+        tempStatus = isRoutine
+          ? normalizeRoutineStatus(v as ElementStatus)
+          : (v as ElementStatus);
       },
       className: 'w-full',
     });
@@ -205,62 +220,64 @@ export class EditElementModal {
     formContent.appendChild(statusField.element);
 
     // Priority segmented control with label
-    this.priorityControl = createSegmentedControl({
-      size: 'md',
-      fullWidth: true,
-      ariaLabel: 'Priority',
-      options: [
-        {
-          id: 'priority-lowest',
-          value: 'lowest',
-          label: 'Lowest',
-          icon: 'chevron-double-down',
-          iconColorClassName: 'text-sky-500',
-          title: 'Lowest priority. Can be ignored for now.',
+    if (!isRoutine) {
+      this.priorityControl = createSegmentedControl({
+        size: 'md',
+        fullWidth: true,
+        ariaLabel: 'Priority',
+        options: [
+          {
+            id: 'priority-lowest',
+            value: 'lowest',
+            label: 'Lowest',
+            icon: 'chevron-double-down',
+            iconColorClassName: 'text-sky-500',
+            title: 'Lowest priority. Can be ignored for now.',
+          },
+          {
+            id: 'priority-low',
+            value: 'low',
+            label: 'Low',
+            icon: 'chevron-down',
+            iconColorClassName: 'text-sky-500',
+            title: 'Low urgency. Important, but not time-sensitive.',
+          },
+          {
+            id: 'priority-medium',
+            value: 'medium',
+            label: 'Medium',
+            icon: 'bars-2',
+            iconColorClassName: 'text-orange-500',
+            title: 'Balanced priority for regular planning and execution.',
+          },
+          {
+            id: 'priority-high',
+            value: 'high',
+            label: 'High',
+            icon: 'chevron-up',
+            iconColorClassName: 'text-red-500',
+            title: 'High urgency. Should be scheduled and completed soon.',
+          },
+          {
+            id: 'priority-highest',
+            value: 'highest',
+            label: 'Highest',
+            icon: 'chevron-double-up',
+            iconColorClassName: 'text-red-500',
+            title: 'Highest priority. Super urgent and should be handled immediately.',
+          },
+        ],
+        value: tempPriority,
+        onChange: (value) => {
+          tempPriority = value;
         },
-        {
-          id: 'priority-low',
-          value: 'low',
-          label: 'Low',
-          icon: 'chevron-down',
-          iconColorClassName: 'text-sky-500',
-          title: 'Low urgency. Important, but not time-sensitive.',
-        },
-        {
-          id: 'priority-medium',
-          value: 'medium',
-          label: 'Medium',
-          icon: 'bars-2',
-          iconColorClassName: 'text-orange-500',
-          title: 'Balanced priority for regular planning and execution.',
-        },
-        {
-          id: 'priority-high',
-          value: 'high',
-          label: 'High',
-          icon: 'chevron-up',
-          iconColorClassName: 'text-red-500',
-          title: 'High urgency. Should be scheduled and completed soon.',
-        },
-        {
-          id: 'priority-highest',
-          value: 'highest',
-          label: 'Highest',
-          icon: 'chevron-double-up',
-          iconColorClassName: 'text-red-500',
-          title: 'Highest priority. Super urgent and should be handled immediately.',
-        },
-      ],
-      value: tempPriority,
-      onChange: (value) => {
-        tempPriority = value;
-      },
-    });
-    const priorityField = createField({
-      label: 'Priority',
-      control: this.priorityControl.element,
-    });
-    formContent.appendChild(priorityField.element);
+      });
+      const priorityField = createField({
+        label: 'Priority',
+        control: this.priorityControl.element,
+      });
+      formContent.appendChild(priorityField.element);
+    }
 
     if (isTask) {
       const dueDateField = createField({ label: 'Due date' });
@@ -337,7 +354,9 @@ export class EditElementModal {
         patch.description = tempDescription;
       }
       if (tempStatus !== originalStatus) patch.status = tempStatus;
-      if (tempPriority !== originalPriority) patch.priority = tempPriority;
+      if (!isRoutine && tempPriority !== originalPriority) {
+        patch.priority = tempPriority;
+      }
       if (isTask && tempDueDateValue !== originalDueDateValue) {
         const nextDueDate = parseDateInputValue(tempDueDateValue);
         patch.dueDate = nextDueDate;
@@ -346,7 +365,7 @@ export class EditElementModal {
       this.element.title = normalizedTitle;
       this.element.description = tempDescription;
       this.element.status = tempStatus;
-      this.element.priority = tempPriority;
+      if (priorityElement) priorityElement.priority = tempPriority;
       let scaleChanged = false;
       if (this.element instanceof GoalElement) {
         if (originalScale !== tempScale) {

--- a/src/features/canvas/ui/components/ExistingEntityPicker.ts
+++ b/src/features/canvas/ui/components/ExistingEntityPicker.ts
@@ -35,6 +35,8 @@ type ExistingEntityPickerConfig<TItem> = {
   getTitle: (item: TItem) => string;
   getDescription?: (item: TItem) => string | null | undefined;
   getStatus?: (item: TItem) => unknown;
+  getStatusLabel?: (status: unknown, item: TItem) => string;
+  getStatusPalette?: (status: unknown, item: TItem) => string;
   getPriority?: (item: TItem) => unknown;
   getUpdatedAt?: (item: TItem) => unknown;
   onCanvasLabel?: string;
@@ -478,8 +480,10 @@ export class ExistingEntityPicker<TItem> {
       const statusValue = this.config.getStatus?.(item);
       if (statusValue !== undefined && statusValue !== null) {
         const statusChip = this.createChip(
-          this.formatEnum(statusValue),
-          this.getStatusChipPalette(statusValue)
+          this.config.getStatusLabel?.(statusValue, item) ??
+            this.formatEnum(statusValue),
+          this.config.getStatusPalette?.(statusValue, item) ??
+            this.getStatusChipPalette(statusValue)
         );
         meta.append(statusChip);
       }

--- a/src/features/canvas/ui/components/ExistingRoutinePicker.ts
+++ b/src/features/canvas/ui/components/ExistingRoutinePicker.ts
@@ -1,0 +1,44 @@
+import type { Observable } from 'rxjs';
+import type { Habit } from '../../../../majom-wrapper/interfaces/index.ts';
+import {
+  ExistingEntityPicker,
+  type ExistingEntityPickerOpenOptions,
+  type ExistingPickerPage,
+} from './ExistingEntityPicker.ts';
+
+export class ExistingRoutinePicker {
+  private readonly picker: ExistingEntityPicker<Habit>;
+
+  constructor(
+    loadRoutinesPage: (
+      term: string,
+      page: number,
+      pageSize: number
+    ) => Observable<ExistingPickerPage<Habit>>,
+    pageSize: number = 30
+  ) {
+    this.picker = new ExistingEntityPicker<Habit>(
+      loadRoutinesPage,
+      {
+        drawerTitle: 'Add existing routine',
+        searchPlaceholder: 'Search routines...',
+        itemLabel: 'Routine',
+        dragKind: 'existing-routine',
+        getTitle: (routine) => routine.title || 'Untitled routine',
+        getDescription: (routine) => routine.description,
+        getStatus: (routine) => routine.status,
+        getUpdatedAt: (routine) =>
+          (routine as Habit & { updated_at?: unknown }).updated_at,
+      },
+      pageSize
+    );
+  }
+
+  public open(options: ExistingEntityPickerOpenOptions<Habit>): void {
+    this.picker.open(options);
+  }
+
+  public close(): void {
+    this.picker.close();
+  }
+}

--- a/src/features/canvas/ui/components/ExistingRoutinePicker.ts
+++ b/src/features/canvas/ui/components/ExistingRoutinePicker.ts
@@ -1,5 +1,11 @@
 import type { Observable } from 'rxjs';
 import type { Habit } from '../../../../majom-wrapper/interfaces/index.ts';
+import { mapStatus } from '../../../../majom-wrapper/utils/statusMapping.ts';
+import {
+  getRoutineStatusChipPalette,
+  getRoutineStatusLabel,
+  normalizeRoutineStatus,
+} from '../../elements/routineStatus.ts';
 import {
   ExistingEntityPicker,
   type ExistingEntityPickerOpenOptions,
@@ -27,6 +33,14 @@ export class ExistingRoutinePicker {
         getTitle: (routine) => routine.title || 'Untitled routine',
         getDescription: (routine) => routine.description,
         getStatus: (routine) => routine.status,
+        getStatusLabel: (status) => {
+          const mapped = normalizeRoutineStatus(mapStatus(status as any));
+          return getRoutineStatusLabel(mapped);
+        },
+        getStatusPalette: (status) => {
+          const mapped = normalizeRoutineStatus(mapStatus(status as any));
+          return getRoutineStatusChipPalette(mapped);
+        },
         getUpdatedAt: (routine) =>
           (routine as Habit & { updated_at?: unknown }).updated_at,
       },

--- a/src/features/canvas/ui/components/StatusSelector.ts
+++ b/src/features/canvas/ui/components/StatusSelector.ts
@@ -6,6 +6,12 @@ import {
   STATUS_ICON_TONE_CLASS,
   STATUS_ORDER,
 } from '../statusPresentation.ts';
+import {
+  getRoutineStatusIcon,
+  getRoutineStatusIconToneClass,
+  getRoutineStatusLabel,
+  ROUTINE_STATUS_ORDER,
+} from '../../elements/routineStatus.ts';
 
 const STATUS_LABEL_TONE_CLASS: Record<ElementStatus, string> = {
   [ElementStatus.Done]: 'text-emerald-700',
@@ -46,6 +52,45 @@ const STATUS_STEP_ORDER: readonly ElementStatus[] = [
   ElementStatus.Done,
 ];
 
+type StatusSelectorMode = 'default' | 'routine';
+
+type StatusSelectorPreset = {
+  order: readonly ElementStatus[];
+  getLabel: (status: ElementStatus) => string;
+  getIcon: (status: ElementStatus) => IconName;
+  getIconToneClass: (status: ElementStatus) => string;
+  getLabelToneClass: (status: ElementStatus) => string;
+  getTriggerBgClass: (status: ElementStatus) => string;
+  getStepToneClass: (status: ElementStatus) => string;
+};
+
+const STATUS_SELECTOR_PRESETS: Record<StatusSelectorMode, StatusSelectorPreset> =
+  {
+    default: {
+      order: STATUS_STEP_ORDER,
+      getLabel: getStatusLabel,
+      getIcon: (status) => STATUS_ICON_MAP[status],
+      getIconToneClass: (status) => STATUS_ICON_TONE_CLASS[status],
+      getLabelToneClass: (status) => STATUS_LABEL_TONE_CLASS[status],
+      getTriggerBgClass: (status) => STATUS_TRIGGER_BG_CLASS[status],
+      getStepToneClass: (status) => STATUS_STEP_TONE_CLASS[status],
+    },
+    routine: {
+      order: ROUTINE_STATUS_ORDER,
+      getLabel: getRoutineStatusLabel,
+      getIcon: getRoutineStatusIcon,
+      getIconToneClass: getRoutineStatusIconToneClass,
+      getLabelToneClass: (status) =>
+        status === ElementStatus.Done ? 'text-slate-700' : 'text-blue-700',
+      getTriggerBgClass: (status) =>
+        status === ElementStatus.Done ? 'bg-slate-100' : 'bg-blue-100/70',
+      getStepToneClass: (status) =>
+        status === ElementStatus.Done
+          ? 'bg-slate-100 text-slate-600 hover:bg-slate-200/80 hover:text-slate-700'
+          : 'bg-blue-100/60 text-blue-600 hover:bg-blue-100 hover:text-blue-700',
+    },
+  };
+
 type StatusSelectorOptions = {
   onStatusChange: (status: ElementStatus) => void;
 };
@@ -60,6 +105,7 @@ export class StatusSelector {
   private readonly panel: HTMLDivElement;
   private readonly statusLabel: HTMLSpanElement;
   private currentStatus: ElementStatus | null = null;
+  private mode: StatusSelectorMode = 'default';
   private open = false;
 
   constructor(options: StatusSelectorOptions) {
@@ -121,6 +167,12 @@ export class StatusSelector {
 
   public setState(status: ElementStatus | null): void {
     this.currentStatus = status;
+    this.syncUi();
+  }
+
+  public setMode(mode: StatusSelectorMode): void {
+    if (this.mode === mode) return;
+    this.mode = mode;
     this.syncUi();
   }
 
@@ -231,13 +283,14 @@ export class StatusSelector {
 
   private renderOptions(): void {
     this.panel.innerHTML = '';
-    STATUS_ORDER.forEach((status) => {
+    const preset = STATUS_SELECTOR_PRESETS[this.mode];
+    preset.order.forEach((status) => {
       const isActive = this.currentStatus === status;
-      const leading = createIcon(STATUS_ICON_MAP[status], {
+      const leading = createIcon(preset.getIcon(status), {
         size: 14,
         strokeWidth: 1.7,
       });
-      leading.classList.add('shrink-0', STATUS_ICON_TONE_CLASS[status]);
+      leading.classList.add('shrink-0', preset.getIconToneClass(status));
 
       const trailing = isActive
         ? createIcon('check', { size: 14, strokeWidth: 2 })
@@ -254,7 +307,7 @@ export class StatusSelector {
       content.className = 'inline-flex min-w-0 items-center gap-2';
       const label = document.createElement('span');
       label.className = 'truncate';
-      label.textContent = getStatusLabel(status);
+      label.textContent = preset.getLabel(status);
       content.append(leading, label);
       option.appendChild(content);
       if (trailing) {
@@ -289,19 +342,23 @@ export class StatusSelector {
       this.prevBtn.disabled = true;
       this.nextBtn.disabled = true;
     } else {
-      this.statusLabel.textContent = getStatusLabel(this.currentStatus);
+      this.statusLabel.textContent =
+        STATUS_SELECTOR_PRESETS[this.mode].getLabel(this.currentStatus);
       this.setStatusLabelTone(this.currentStatus);
       this.setTriggerStatusBackground(this.currentStatus);
       this.setStepButtonsStatusTone(this.currentStatus);
 
-      const index = STATUS_STEP_ORDER.indexOf(this.currentStatus);
+      const index = STATUS_SELECTOR_PRESETS[this.mode].order.indexOf(
+        this.currentStatus
+      );
       this.prevBtn.disabled = index <= 0;
-      this.nextBtn.disabled = index >= STATUS_STEP_ORDER.length - 1;
+      this.nextBtn.disabled =
+        index >= STATUS_SELECTOR_PRESETS[this.mode].order.length - 1;
     }
 
     const triggerText =
       this.currentStatus !== null
-        ? getStatusLabel(this.currentStatus)
+        ? STATUS_SELECTOR_PRESETS[this.mode].getLabel(this.currentStatus)
         : 'Mixed status';
     this.triggerBtn.title = `Status: ${triggerText}`;
     this.triggerBtn.setAttribute('aria-label', `Status: ${triggerText}`);
@@ -313,11 +370,12 @@ export class StatusSelector {
 
   private stepStatus(direction: -1 | 1): void {
     if (this.currentStatus === null) return;
-    const currentIndex = STATUS_STEP_ORDER.indexOf(this.currentStatus);
+    const order = STATUS_SELECTOR_PRESETS[this.mode].order;
+    const currentIndex = order.indexOf(this.currentStatus);
     if (currentIndex === -1) return;
     const nextIndex = currentIndex + direction;
-    if (nextIndex < 0 || nextIndex >= STATUS_STEP_ORDER.length) return;
-    const nextStatus = STATUS_STEP_ORDER[nextIndex];
+    if (nextIndex < 0 || nextIndex >= order.length) return;
+    const nextStatus = order[nextIndex];
     this.currentStatus = nextStatus;
     this.syncUi();
     this.onStatusChange(nextStatus);
@@ -333,7 +391,9 @@ export class StatusSelector {
       this.statusLabel.classList.add(STATUS_LABEL_MIXED_TONE_CLASS);
       return;
     }
-    this.statusLabel.classList.add(STATUS_LABEL_TONE_CLASS[status]);
+    this.statusLabel.classList.add(
+      STATUS_SELECTOR_PRESETS[this.mode].getLabelToneClass(status)
+    );
   }
 
   private setTriggerStatusBackground(status: ElementStatus | null): void {
@@ -345,7 +405,9 @@ export class StatusSelector {
       this.triggerBtn.classList.add(STATUS_TRIGGER_MIXED_BG_CLASS);
       return;
     }
-    this.triggerBtn.classList.add(STATUS_TRIGGER_BG_CLASS[status]);
+    this.triggerBtn.classList.add(
+      STATUS_SELECTOR_PRESETS[this.mode].getTriggerBgClass(status)
+    );
   }
 
   private setStepButtonsStatusTone(status: ElementStatus | null): void {
@@ -360,7 +422,7 @@ export class StatusSelector {
     const toneClass =
       status === null
         ? STATUS_STEP_MIXED_TONE_CLASS
-        : STATUS_STEP_TONE_CLASS[status];
+        : STATUS_SELECTOR_PRESETS[this.mode].getStepToneClass(status);
     const tokens = toneClass.split(' ').filter(Boolean);
     this.prevBtn.classList.add(...tokens);
     this.nextBtn.classList.add(...tokens);

--- a/src/features/canvas/ui/events/existingPickerEvents.ts
+++ b/src/features/canvas/ui/events/existingPickerEvents.ts
@@ -1,7 +1,8 @@
 export type ExistingPickerKind =
   | 'existing-goal'
   | 'existing-story'
-  | 'existing-task';
+  | 'existing-task'
+  | 'existing-routine';
 
 export const EXISTING_PICKER_EVENT_NAMES = {
   dragStateChanged: 'existingPickerDragStateChanged',

--- a/src/majom-wrapper/services/CanvasDataService.ts
+++ b/src/majom-wrapper/services/CanvasDataService.ts
@@ -48,6 +48,7 @@ import type {
   Habit,
 } from '../interfaces/index.ts';
 import { ElementStatus } from '../../features/canvas/elements/ElementStatus.ts';
+import { mapRoutineStatusToBackend } from '../../features/canvas/elements/routineStatus.ts';
 import Connection from '../../features/canvas/core/shapes/Connection.ts';
 import {
   ConnectionRelationType,
@@ -730,7 +731,7 @@ export class CanvasDataService {
         if (req.patch.description !== undefined)
           routinePayload.description = req.patch.description;
         if (req.patch.status !== undefined)
-          routinePayload.status = mapStatusToBackend(req.patch.status) as any;
+          routinePayload.status = mapRoutineStatusToBackend(req.patch.status);
         if (Object.keys(routinePayload).length === 0) return of(undefined);
         return this.habitsApi.patchHabit(ref, routinePayload);
       }),

--- a/src/majom-wrapper/services/CanvasDataService.ts
+++ b/src/majom-wrapper/services/CanvasDataService.ts
@@ -19,6 +19,7 @@ import {
 import { TasksApiService } from '../data-access/tasks-api-service.ts';
 import { StoriesApiService } from '../data-access/stories-api-service.ts';
 import { GoalsApiService } from '../data-access/goals-api-service.ts';
+import { HabitsApiService } from '../data-access/habits-api-service.ts';
 import { CanvasRelationsApiService } from '../data-access/canvas-relations-api-service.ts';
 import {
   CanvasApiService,
@@ -27,9 +28,11 @@ import {
 import { mapTask } from '../../features/canvas/mappers/task-mapper.ts';
 import { mapStory } from '../../features/canvas/mappers/story-mapper.ts';
 import { mapGoal } from '../../features/canvas/mappers/goal-mapper.ts';
+import { mapRoutine } from '../../features/canvas/mappers/routine-mapper.ts';
 import { TaskElement } from '../../features/canvas/elements/TaskElement.ts';
 import { StoryElement } from '../../features/canvas/elements/StoryElement.ts';
 import { GoalElement } from '../../features/canvas/elements/GoalElement.ts';
+import { RoutineElement } from '../../features/canvas/elements/RoutineElement.ts';
 import { mapStatusToBackend } from '../utils/statusMapping.ts';
 import {
   mapPriorityToBackend,
@@ -42,6 +45,7 @@ import type {
   PlatformTask,
   Story,
   Goal,
+  Habit,
 } from '../interfaces/index.ts';
 import { ElementStatus } from '../../features/canvas/elements/ElementStatus.ts';
 import Connection from '../../features/canvas/core/shapes/Connection.ts';
@@ -61,6 +65,7 @@ type ElementPatch = Partial<{
 }>;
 
 type RelationElementType = 'task' | 'story' | 'goal';
+type CanvasElementType = RelationElementType | 'routine';
 
 type ElementUpdateStatus = {
   status: 'saving' | 'saved' | 'failed';
@@ -69,7 +74,7 @@ type ElementUpdateStatus = {
 
 type ElementUpdateRequest = {
   key: string;
-  element: TaskElement | StoryElement | GoalElement;
+  element: TaskElement | StoryElement | GoalElement | RoutineElement;
   patch: ElementPatch;
 };
 
@@ -91,13 +96,13 @@ export type CanvasElementsLoadState =
     }
   | {
       phase: 'elements-partial-ready';
-      elements: Array<TaskElement | StoryElement | GoalElement>;
+      elements: Array<TaskElement | StoryElement | GoalElement | RoutineElement>;
       placeholders: CanvasLoadingPlaceholder[];
       focusedElementUuid: string | null;
     }
   | {
       phase: 'elements-ready';
-      elements: Array<TaskElement | StoryElement | GoalElement>;
+      elements: Array<TaskElement | StoryElement | GoalElement | RoutineElement>;
       focusedElementUuid: string | null;
     };
 
@@ -140,9 +145,11 @@ export class CanvasDataService {
   private tasks$?: Observable<PlatformTask[]>;
   private stories$?: Observable<Story[]>;
   private goals$?: Observable<Goal[]>;
+  private habits$?: Observable<Habit[]>;
   private tasksCache: PlatformTask[] | null = null;
   private storiesCache: Story[] | null = null;
   private goalsCache: Goal[] | null = null;
+  private habitsCache: Habit[] | null = null;
   private positionRegistry: Map<string, PositionSnapshot> = new Map();
   private positionDirtyKeys = new Set<string>();
   private relationRegistry: Map<string, CanvasRelation> = new Map();
@@ -158,6 +165,7 @@ export class CanvasDataService {
     private tasksApi: TasksApiService,
     private storiesApi: StoriesApiService,
     private goalsApi: GoalsApiService,
+    private habitsApi: HabitsApiService,
     private canvasApi: CanvasApiService,
     private relationsApi: CanvasRelationsApiService
   ) {
@@ -165,10 +173,10 @@ export class CanvasDataService {
   }
 
   /**
-   * Load tasks, stories, goals along with their canvas positions.
+   * Load tasks, stories, goals, routines along with their canvas positions.
    */
   public loadElements(): Observable<
-    Array<TaskElement | StoryElement | GoalElement>
+    Array<TaskElement | StoryElement | GoalElement | RoutineElement>
   > {
     return this.loadElementsProgressive({
       viewportFirstThreshold: this.defaultViewportFirstThreshold,
@@ -360,16 +368,26 @@ export class CanvasDataService {
         maxY: y + diameter,
       };
     }
+    if (entry.element_type === 'routine') {
+      const diameter = this.normalizeCoord(RoutineElement.radius * 2);
+      return {
+        minX: x,
+        minY: y,
+        maxX: x + diameter,
+        maxY: y + diameter,
+      };
+    }
     return { minX: x, minY: y, maxX: x, maxY: y };
   }
 
   private loadElementsByLayout(
     layout: CanvasPositionReadDTO[]
-  ): Observable<Array<TaskElement | StoryElement | GoalElement>> {
+  ): Observable<Array<TaskElement | StoryElement | GoalElement | RoutineElement>> {
     const layoutRefs = {
       task: { ids: new Set<number>(), uuids: new Set<string>() },
       story: { ids: new Set<number>(), uuids: new Set<string>() },
       goal: { ids: new Set<number>(), uuids: new Set<string>() },
+      routine: { ids: new Set<number>(), uuids: new Set<string>() },
     };
     layout.forEach((pos) => {
       const type = pos.element_type;
@@ -385,18 +403,31 @@ export class CanvasDataService {
     const taskUuids = Array.from(layoutRefs.task.uuids);
     const storyUuids = Array.from(layoutRefs.story.uuids);
     const goalUuids = Array.from(layoutRefs.goal.uuids);
+    const routineUuids = Array.from(layoutRefs.routine.uuids);
     return this.fetchTasksByRefsCached(taskIds, taskUuids).pipe(
       switchMap((tasks) =>
         this.fetchStoriesByRefsCached(storyIds, storyUuids).pipe(
           switchMap((stories) =>
             this.fetchGoalsByRefsCached(goalIds, goalUuids).pipe(
-              map((goals) => {
-                const taskElements = tasks.map((t) => mapTask(t, layout));
-                const storyElements = stories.map((s) => mapStory(s, layout));
-                const goalElements = goals.map((g) => mapGoal(g, layout));
-                this.linkTasksToStories(taskElements, storyElements, tasks);
-                return [...taskElements, ...storyElements, ...goalElements];
-              })
+              switchMap((goals) =>
+                this.fetchRoutinesByRefsCached(routineUuids).pipe(
+                  map((routines) => {
+                    const taskElements = tasks.map((t) => mapTask(t, layout));
+                    const storyElements = stories.map((s) => mapStory(s, layout));
+                    const goalElements = goals.map((g) => mapGoal(g, layout));
+                    const routineElements = routines.map((r) =>
+                      mapRoutine(r, layout)
+                    );
+                    this.linkTasksToStories(taskElements, storyElements, tasks);
+                    return [
+                      ...taskElements,
+                      ...storyElements,
+                      ...goalElements,
+                      ...routineElements,
+                    ];
+                  })
+                )
+              )
             )
           )
         )
@@ -405,12 +436,12 @@ export class CanvasDataService {
   }
 
   private mergeLoadedElements(
-    primary: Array<TaskElement | StoryElement | GoalElement>,
-    secondary: Array<TaskElement | StoryElement | GoalElement>
-  ): Array<TaskElement | StoryElement | GoalElement> {
+    primary: Array<TaskElement | StoryElement | GoalElement | RoutineElement>,
+    secondary: Array<TaskElement | StoryElement | GoalElement | RoutineElement>
+  ): Array<TaskElement | StoryElement | GoalElement | RoutineElement> {
     const mergedById = new Map<
       string,
-      TaskElement | StoryElement | GoalElement
+      TaskElement | StoryElement | GoalElement | RoutineElement
     >();
     primary.forEach((element) => mergedById.set(element.id, element));
     secondary.forEach((element) => mergedById.set(element.id, element));
@@ -464,6 +495,18 @@ export class CanvasDataService {
           width: this.normalizeCoord(diameter),
           height: this.normalizeCoord(diameter),
         });
+        return;
+      }
+      if (entry.element_type === 'routine') {
+        const diameter = RoutineElement.radius * 2;
+        placeholders.push({
+          elementType: 'routine',
+          elementUuid: entry.element_uuid,
+          x: this.normalizeCoord(entry.x),
+          y: this.normalizeCoord(entry.y),
+          width: this.normalizeCoord(diameter),
+          height: this.normalizeCoord(diameter),
+        });
       }
     });
     return placeholders;
@@ -492,7 +535,7 @@ export class CanvasDataService {
 
   public updateCanvasRelations(
     connections: IConnection[],
-    elements: Array<TaskElement | StoryElement | GoalElement>
+    elements: Array<TaskElement | StoryElement | GoalElement | RoutineElement>
   ): Observable<void> {
     if (!this.canvasId) return of(undefined);
     const elementRefs = this.buildElementRefMap(elements);
@@ -553,7 +596,7 @@ export class CanvasDataService {
 
   public hasRelationChanges(
     connections: IConnection[],
-    elements: Array<TaskElement | StoryElement | GoalElement>
+    elements: Array<TaskElement | StoryElement | GoalElement | RoutineElement>
   ): boolean {
     if (!this.canvasId) return connections.length > 0;
     const elementRefs = this.buildElementRefMap(elements);
@@ -598,14 +641,16 @@ export class CanvasDataService {
   }
 
   private getElementUpdateKey(
-    element: TaskElement | StoryElement | GoalElement
+    element: TaskElement | StoryElement | GoalElement | RoutineElement
   ): string {
     const type =
       element instanceof TaskElement
         ? 'task'
         : element instanceof StoryElement
           ? 'story'
-          : 'goal';
+          : element instanceof GoalElement
+            ? 'goal'
+            : 'routine';
     return `${type}:${element.id}`;
   }
 
@@ -677,7 +722,17 @@ export class CanvasDataService {
         if (req.element instanceof StoryElement) {
           return this.storiesApi.patchStory(ref, payload as Partial<Story>);
         }
-        return this.goalsApi.patchGoal(ref, payload as Partial<Goal>);
+        if (req.element instanceof GoalElement) {
+          return this.goalsApi.patchGoal(ref, payload as Partial<Goal>);
+        }
+        const routinePayload: Partial<Habit> = {};
+        if (req.patch.title !== undefined) routinePayload.title = req.patch.title;
+        if (req.patch.description !== undefined)
+          routinePayload.description = req.patch.description;
+        if (req.patch.status !== undefined)
+          routinePayload.status = mapStatusToBackend(req.patch.status) as any;
+        if (Object.keys(routinePayload).length === 0) return of(undefined);
+        return this.habitsApi.patchHabit(ref, routinePayload);
       }),
       tap((updated) => {
         if (!updated) return;
@@ -685,8 +740,10 @@ export class CanvasDataService {
           this.upsertTaskCache(updated as PlatformTask);
         } else if (updated && req.element instanceof StoryElement) {
           this.upsertStoryCache(updated as Story);
-        } else if (updated) {
+        } else if (updated && req.element instanceof GoalElement) {
           this.upsertGoalCache(updated as Goal);
+        } else if (updated) {
+          this.upsertHabitCache(updated as Habit);
         }
         const activeCanvasId = this.canvasId;
         if (activeCanvasId) {
@@ -720,7 +777,7 @@ export class CanvasDataService {
     story: StoryElement | null
   ): Observable<void> {
     const elementsToPersist = [task, story].filter(Boolean) as Array<
-      TaskElement | StoryElement | GoalElement
+      TaskElement | StoryElement | GoalElement | RoutineElement
     >;
     return this.ensureElementsPersisted(elementsToPersist).pipe(
       switchMap(() => {
@@ -768,7 +825,7 @@ export class CanvasDataService {
     options: StoryGoalLinkOptions = {}
   ): Observable<StoryGoalLinkResult> {
     const elementsToPersist = [story, goal].filter(Boolean) as Array<
-      TaskElement | StoryElement | GoalElement
+      TaskElement | StoryElement | GoalElement | RoutineElement
     >;
     return this.ensureElementsPersisted(elementsToPersist).pipe(
       switchMap(() => {
@@ -888,7 +945,7 @@ export class CanvasDataService {
     this.elementUpdateStatus$.asObservable();
 
   public queueElementUpdate(
-    element: TaskElement | StoryElement | GoalElement,
+    element: TaskElement | StoryElement | GoalElement | RoutineElement,
     patch: ElementPatch
   ): void {
     if (!patch || Object.keys(patch).length === 0) return;
@@ -951,7 +1008,8 @@ export class CanvasDataService {
       const isPlanningType =
         snapshot.element_type === 'task' ||
         snapshot.element_type === 'story' ||
-        snapshot.element_type === 'goal';
+        snapshot.element_type === 'goal' ||
+        snapshot.element_type === 'routine';
       if (!isPlanningType) continue;
       if (!snapshot.meta || snapshot.meta.focused !== true) continue;
       return snapshot.element_uuid;
@@ -965,7 +1023,8 @@ export class CanvasDataService {
       const isPlanningType =
         snapshot.element_type === 'task' ||
         snapshot.element_type === 'story' ||
-        snapshot.element_type === 'goal';
+        snapshot.element_type === 'goal' ||
+        snapshot.element_type === 'routine';
       if (!isPlanningType) continue;
       if (!snapshot.meta || snapshot.meta.highlighted !== true) continue;
       highlighted.push(snapshot.element_uuid);
@@ -986,16 +1045,18 @@ export class CanvasDataService {
     this.tasksCache = null;
     this.storiesCache = null;
     this.goalsCache = null;
+    this.habitsCache = null;
     this.tasks$ = undefined;
     this.stories$ = undefined;
     this.goals$ = undefined;
+    this.habits$ = undefined;
     this.positionRegistry.clear();
     this.positionDirtyKeys.clear();
     this.relationRegistry.clear();
   }
 
   public markPositionsDirty(
-    elements: Array<TaskElement | StoryElement | GoalElement>
+    elements: Array<TaskElement | StoryElement | GoalElement | RoutineElement>
   ): void {
     if (elements.length === 0) return;
     elements.forEach((el) => {
@@ -1007,7 +1068,7 @@ export class CanvasDataService {
   }
 
   public ensureElementsPersisted(
-    elements: Array<TaskElement | StoryElement | GoalElement>
+    elements: Array<TaskElement | StoryElement | GoalElement | RoutineElement>
   ): Observable<void> {
     const toCreate = elements.filter(
       (el) => !Number.isFinite(this.getBackendId(el))
@@ -1073,6 +1134,26 @@ export class CanvasDataService {
                 el.uuid = created.uuid;
               }
               this.upsertGoalCache(created);
+              return created;
+            })
+          )
+        );
+      } else if (el instanceof RoutineElement) {
+        const payload: Partial<Habit> = {
+          title: el.title,
+          description: el.description,
+          status: mapStatusToBackend(el.status) as any,
+        };
+        creates.push(
+          this.habitsApi.createHabit(payload).pipe(
+            map((created) => {
+              el.backendId = created.id;
+              const createdUuid = (created as Habit & { uuid?: unknown }).uuid;
+              el.uuid =
+                typeof createdUuid === 'string' && createdUuid.trim().length > 0
+                  ? createdUuid
+                  : `habit-${created.id}`;
+              this.upsertHabitCache(created);
               return created;
             })
           )
@@ -1228,6 +1309,25 @@ export class CanvasDataService {
     );
   }
 
+
+
+  private fetchRoutinesByRefsCached(uuids: string[]): Observable<Habit[]> {
+    if (uuids.length === 0) return of([]);
+    return this.loadHabitsCached().pipe(
+      map((habits) => {
+        const refSet = new Set(uuids);
+        return habits.filter((habit) => {
+          const rawUuid = (habit as Habit & { uuid?: unknown }).uuid;
+          const habitUuid =
+            typeof rawUuid === 'string' && rawUuid.trim().length > 0
+              ? rawUuid
+              : `habit-${habit.id}`;
+          return refSet.has(habitUuid);
+        });
+      })
+    );
+  }
+
   private loadTasksCached(force: boolean = false): Observable<PlatformTask[]> {
     if (!force && this.tasksCache) return of(this.tasksCache);
     if (!force && this.tasks$) return this.tasks$;
@@ -1267,6 +1367,21 @@ export class CanvasDataService {
       shareReplay(1)
     );
     return this.goals$;
+  }
+
+
+
+  private loadHabitsCached(force: boolean = false): Observable<Habit[]> {
+    if (!force && this.habitsCache) return of(this.habitsCache);
+    if (!force && this.habits$) return this.habits$;
+    this.habits$ = this.habitsApi.getHabits().pipe(
+      map((items) => {
+        this.habitsCache = items;
+        return items;
+      }),
+      shareReplay(1)
+    );
+    return this.habits$;
   }
 
   private getCachedByIds<T extends { id: number }>(
@@ -1377,6 +1492,19 @@ export class CanvasDataService {
     }
   }
 
+  private upsertHabitCache(habit: Habit): void {
+    if (!this.habitsCache) {
+      this.habitsCache = [habit];
+      return;
+    }
+    const idx = this.habitsCache.findIndex((h) => h.id === habit.id);
+    if (idx >= 0) {
+      this.habitsCache[idx] = habit;
+    } else {
+      this.habitsCache.push(habit);
+    }
+  }
+
   public setActiveCanvas(
     canvas: Pick<CanvasSummary, 'id' | 'name' | 'meta'>
   ): void {
@@ -1404,7 +1532,9 @@ export class CanvasDataService {
         ? 'task'
         : req.element instanceof StoryElement
           ? 'story'
-          : 'goal';
+          : req.element instanceof GoalElement
+            ? 'goal'
+            : 'routine';
     CanvasClientStorage.upsertUnsyncedDraft(this.canvasId, {
       id: this.getElementDraftId(req),
       kind: 'element-patch',
@@ -1592,7 +1722,7 @@ export class CanvasDataService {
   }
 
   public getRemovedPositionIds(
-    elements: Array<TaskElement | StoryElement | GoalElement>
+    elements: Array<TaskElement | StoryElement | GoalElement | RoutineElement>
   ): string[] {
     if (this.positionRegistry.size === 0) return [];
     const activeKeys = this.getElementKeys(elements);
@@ -1606,7 +1736,7 @@ export class CanvasDataService {
   }
 
   public needsPositionRefresh(
-    elements: Array<TaskElement | StoryElement | GoalElement>
+    elements: Array<TaskElement | StoryElement | GoalElement | RoutineElement>
   ): boolean {
     const keys = this.getElementKeys(elements);
     for (const key of keys) {
@@ -1638,7 +1768,7 @@ export class CanvasDataService {
   }
 
   public getPositionIdForElement(
-    element: TaskElement | StoryElement | GoalElement
+    element: TaskElement | StoryElement | GoalElement | RoutineElement
   ): string | null {
     const key = this.getPositionKeyForElement(element);
     if (!key) return null;
@@ -1646,10 +1776,9 @@ export class CanvasDataService {
   }
 
   public deleteElement(
-    element: TaskElement | StoryElement | GoalElement
+    element: TaskElement | StoryElement | GoalElement | RoutineElement
   ): Observable<void> {
-    const type = this.getElementType(element);
-    if (!type) return of(undefined);
+    const type = this.getCanvasElementType(element);
     const ref = this.getBackendRef(element);
     if (!ref) {
       return this.deletePositionForElement(element);
@@ -1659,7 +1788,9 @@ export class CanvasDataService {
         ? this.tasksApi.deleteTask(ref)
         : element instanceof StoryElement
           ? this.storiesApi.deleteStory(ref)
-          : this.goalsApi.deleteGoal(ref);
+          : element instanceof GoalElement
+            ? this.goalsApi.deleteGoal(ref)
+            : this.habitsApi.deleteHabit(Number(ref));
     return deleteEntity$.pipe(
       switchMap(() =>
         this.deletePositionForElement(element).pipe(
@@ -1909,7 +2040,7 @@ export class CanvasDataService {
   }
 
   private getElementKeys(
-    elements: Array<TaskElement | StoryElement | GoalElement>
+    elements: Array<TaskElement | StoryElement | GoalElement | RoutineElement>
   ): Set<string> {
     const keys = new Set<string>();
     elements.forEach((el) => {
@@ -1920,11 +2051,30 @@ export class CanvasDataService {
   }
 
   private getElementType(
-    element: TaskElement | StoryElement | GoalElement
+    element: TaskElement | StoryElement | GoalElement | RoutineElement
   ): RelationElementType | null {
     if (element instanceof TaskElement) return 'task';
     if (element instanceof StoryElement) return 'story';
     if (element instanceof GoalElement) return 'goal';
+    return null;
+  }
+
+  private getCanvasElementType(
+    element: TaskElement | StoryElement | GoalElement | RoutineElement
+  ): CanvasElementType {
+    if (element instanceof TaskElement) return 'task';
+    if (element instanceof StoryElement) return 'story';
+    if (element instanceof GoalElement) return 'goal';
+    return 'routine';
+  }
+
+  private getLayoutUuidForElement(
+    element: TaskElement | StoryElement | GoalElement | RoutineElement
+  ): string | null {
+    if (element.uuid) return element.uuid;
+    if (element instanceof RoutineElement && Number.isFinite(element.backendId)) {
+      return `habit-${element.backendId}`;
+    }
     return null;
   }
 
@@ -1973,7 +2123,7 @@ export class CanvasDataService {
   }
 
   private buildElementRefMap(
-    elements: Array<TaskElement | StoryElement | GoalElement>
+    elements: Array<TaskElement | StoryElement | GoalElement | RoutineElement>
   ): Map<string, { uuid: string; type: RelationElementType }> {
     const map = new Map<string, { uuid: string; type: RelationElementType }>();
     elements.forEach((element) => {
@@ -1993,7 +2143,7 @@ export class CanvasDataService {
   }
 
   private getBackendId(
-    element: TaskElement | StoryElement | GoalElement
+    element: TaskElement | StoryElement | GoalElement | RoutineElement
   ): number | null {
     if (Number.isFinite(element.backendId)) {
       return element.backendId ?? null;
@@ -2004,8 +2154,11 @@ export class CanvasDataService {
   }
 
   private getBackendRef(
-    element: TaskElement | StoryElement | GoalElement
+    element: TaskElement | StoryElement | GoalElement | RoutineElement
   ): string | null {
+    if (element instanceof RoutineElement && Number.isFinite(element.backendId)) {
+      return String(element.backendId);
+    }
     if (element.uuid) return element.uuid;
     if (Number.isFinite(element.backendId)) {
       return String(element.backendId);
@@ -2014,11 +2167,12 @@ export class CanvasDataService {
   }
 
   private getPositionKeyForElement(
-    element: TaskElement | StoryElement | GoalElement
+    element: TaskElement | StoryElement | GoalElement | RoutineElement
   ): string | null {
-    const type = this.getElementType(element);
-    if (!type || !element.uuid) return null;
-    return this.buildPositionKey(type, `uuid:${element.uuid}`);
+    const type = this.getCanvasElementType(element);
+    const uuid = this.getLayoutUuidForElement(element);
+    if (!uuid) return null;
+    return this.buildPositionKey(type, `uuid:${uuid}`);
   }
 
   private getPositionKeyFromWrite(pos: CanvasPositionWriteDTO): string | null {
@@ -2146,7 +2300,7 @@ export class CanvasDataService {
   }
 
   private deletePositionForElement(
-    element: TaskElement | StoryElement | GoalElement
+    element: TaskElement | StoryElement | GoalElement | RoutineElement
   ): Observable<void> {
     const key = this.getPositionKeyForElement(element);
     if (!key) return of(undefined);
@@ -2164,7 +2318,7 @@ export class CanvasDataService {
   }
 
   private removePositionByKey(
-    element: TaskElement | StoryElement | GoalElement
+    element: TaskElement | StoryElement | GoalElement | RoutineElement
   ): void {
     const key = this.getPositionKeyForElement(element);
     if (key) {
@@ -2174,7 +2328,7 @@ export class CanvasDataService {
   }
 
   private removeElementFromCache(
-    type: 'task' | 'story' | 'goal',
+    type: CanvasElementType,
     uuid: string
   ): void {
     if (type === 'task' && this.tasksCache) {
@@ -2185,6 +2339,14 @@ export class CanvasDataService {
       );
     } else if (type === 'goal' && this.goalsCache) {
       this.goalsCache = this.goalsCache.filter((goal) => goal.uuid !== uuid);
+    } else if (type === 'routine' && this.habitsCache) {
+      this.habitsCache = this.habitsCache.filter((habit) => {
+        const habitUuid =
+          typeof (habit as Habit & { uuid?: unknown }).uuid === 'string'
+            ? ((habit as Habit & { uuid?: string }).uuid as string)
+            : `habit-${habit.id}`;
+        return habitUuid !== uuid;
+      });
     }
   }
 }

--- a/src/ui-lib/src/hud/icons.ts
+++ b/src/ui-lib/src/hud/icons.ts
@@ -39,7 +39,8 @@ export type IconName =
   | 'arrow-ultum-left'
   | 'arrow-ultum-right'
   | 'status-pending'
-  | 'status-defined';
+  | 'status-defined'
+  | 'archive-box';
 
 export type IconOptions = {
   size?: number;
@@ -378,6 +379,15 @@ export function createIcon(
     svg.appendChild(
       makePath(
         'M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z'
+      )
+    );
+    return svg;
+  }
+
+  if (name === 'archive-box') {
+    svg.appendChild(
+      makePath(
+        'm20.25 7.5-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z'
       )
     );
     return svg;


### PR DESCRIPTION
### Motivation
- Introduce a new planning element type `Routine` (wrapper for existing `Habit` API) so routines can be added, rendered, selected and persisted on the Canvas like `Task/Story/Goal`.
- Reuse the existing backend `HabitsApiService` and integrate routines into existing picker, create-from-context-menu and layout persistence flows.
- Provide a visually distinct circular representation for routines and minimal UX (create/edit title + optional description) suitable for Canvas MVP.

### Description
- Added a new Canvas element `RoutineElement` in `src/features/canvas/elements/RoutineElement.ts` implementing drawing, `contains`, `getBoundaryPoint`, `getConnectionPoints`, and `clone`, with `radius = 56` and circle styling.
- Wired routine support across the UI: added `Routine` item to `ContextMenu`, `createRoutineAt`, and `getElementLabel`/confirm key handling in `src/features/canvas/ui/ContextMenu.ts`.
- Implemented existing-entity flow: `ExistingRoutinePicker` component and `AddExistingRoutineService` to find, focus or add routines to the scene, and added drag/drop event kind `existing-routine` in `existingPickerEvents`.
- Integrated backend and persistence in `CanvasDataService`: registered `HabitsApiService`, added routines loading (`loadHabitsCached`, `fetchRoutinesByRefsCached`), mapping (`mapRoutine`), create/patch/delete support for habits, canvas layout placeholders and position key handling for `routine` type, and cache upsert logic (`upsertHabitCache`).
- Updated `UIManager` and `CanvasApp` to instantiate `HabitsApiService`, hook `ExistingRoutinePicker` and `AddExistingRoutineService`, and include `RoutineElement` in type guards and save/load flows so routines get persisted and considered in layout operations.
- Updated `CanvasManager` drawing placeholders to render `routine` placeholders and focused stroke; added a new mapper file `src/features/canvas/mappers/routine-mapper.ts` and a docs file `docs/ROUTINE-ELEMENT-ON-CANVAS.md` describing implementation notes and integration plan.

### Testing
- Ran project type-check and full build; the project compiled successfully with no type errors.
- Executed the unit test suite including new/updated tests around the `RoutineElement` drawing/`contains` logic, `ContextMenu` menu item presence, and `AddExistingRoutineService` add-or-focus behavior; all unit tests passed.
- Ran integration/smoke tests for Canvas load/save flows and drag/drop existing-entity picker; smoke tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd95a95bc48331a53e8711f0101b75)