### PR TITLE
Hide action buttons on older messages until hover/focus while keeping latest actions visible

### DIFF
--- a/src/features/ai-assistant/components/AiAssistantPanel.test.ts
+++ b/src/features/ai-assistant/components/AiAssistantPanel.test.ts
@@ -263,6 +263,36 @@ describe('AiAssistantPanel auto-scroll', () => {
     panel.unmount();
   });
 
+  it('uses hover/focus CSS visibility for older message actions and keeps latest actions always visible', () => {
+    const state = createState([
+      createMessage('user-1', 'user', 'Older user draft'),
+      createMessage('user-2', 'user', 'Latest user draft'),
+    ]);
+    const { controller } = createController(state);
+    const panel = new AiAssistantPanel({ controller });
+    const { messagesList } = getPanelInternals(panel);
+
+    const copyButtons = Array.from(
+      messagesList.querySelectorAll<HTMLButtonElement>(
+        'button[aria-label="Copy message to clipboard"]'
+      )
+    );
+
+    expect(copyButtons).toHaveLength(2);
+    const olderButton = copyButtons[0];
+    const latestButton = copyButtons[1];
+
+    const olderActions = olderButton.parentElement as HTMLDivElement;
+    const latestActions = latestButton.parentElement as HTMLDivElement;
+    expect(olderActions.classList.contains('opacity-0')).toBe(true);
+    expect(olderActions.classList.contains('group-hover:opacity-100')).toBe(true);
+    expect(
+      olderActions.classList.contains('group-focus-within:opacity-100')
+    ).toBe(true);
+    expect(latestActions.classList.contains('opacity-0')).toBe(false);
+    panel.unmount();
+  });
+
   it('renders a copy button for user messages and copies their text', async () => {
     const writeText = vi.fn(() => Promise.resolve(undefined));
     vi.stubGlobal('navigator', {

--- a/src/features/ai-assistant/components/AiAssistantPanel.ts
+++ b/src/features/ai-assistant/components/AiAssistantPanel.ts
@@ -819,14 +819,15 @@ export class AiAssistantPanel {
         this.createEmptyStateCard(currentView, contextMode, context)
       );
     }
-    messages.forEach((message) => {
+    messages.forEach((message, index) => {
       this.messagesList.appendChild(
         this.createMessageBubble(
           message,
           context,
           contextEnabled,
           replying,
-          message.id === regeneratableMessageId
+          message.id === regeneratableMessageId,
+          index === messages.length - 1
         )
       );
     });
@@ -1129,7 +1130,8 @@ export class AiAssistantPanel {
     context: ReturnType<AiAssistantSessionController['getState']>['context'],
     contextEnabled: boolean,
     replying: boolean,
-    canRegenerate: boolean
+    canRegenerate: boolean,
+    isLastMessage: boolean
   ): HTMLDivElement {
     const isCommandMessage = message.kind === 'command';
     const isSystemMessage =
@@ -1143,6 +1145,9 @@ export class AiAssistantPanel {
     wrap.style.flexDirection = 'column';
     wrap.style.alignItems = isUserMessage ? 'flex-end' : 'flex-start';
     wrap.style.gap = '6px';
+    if (!isLastMessage) {
+      wrap.classList.add('group');
+    }
 
     const meta = document.createElement('div');
     meta.style.display = 'flex';
@@ -1280,6 +1285,18 @@ export class AiAssistantPanel {
       actions.style.justifyContent = 'flex-start';
       actions.style.gap = '6px';
       actions.style.padding = '0 4px';
+      if (!isLastMessage) {
+        actions.classList.add(
+          'opacity-0',
+          'pointer-events-none',
+          'transition-opacity',
+          'duration-150',
+          'group-hover:opacity-100',
+          'group-hover:pointer-events-auto',
+          'group-focus-within:opacity-100',
+          'group-focus-within:pointer-events-auto'
+        );
+      }
 
       if (canRegenerate) {
         const regenerateButton = this.createQuietIconButton({


### PR DESCRIPTION
### Motivation

- Improve UI clarity by hiding action controls (copy/regenerate) on older messages to reduce visual clutter while ensuring the most recent message always shows actions.

### Description

- Added an `isLastMessage` flag to `createMessageBubble` and pass it from the renderer so the component knows which message is the latest.  
- Non-last message wrappers now receive a `group` class and their actions container gets utility classes to make it `opacity-0` and `pointer-events-none` by default and visible on `group-hover`/`group-focus-within`.  
- Updated the messages rendering logic to compute `isLastMessage` via `index === messages.length - 1` when creating bubbles.  
- Added a unit test `uses hover/focus CSS visibility for older message actions and keeps latest actions always visible` to assert the new classes are applied correctly.

### Testing

- Ran the AiAssistantPanel unit tests including the new hover/focus visibility test and the existing copy button test, and they passed.  
- Ran the related test file `src/features/ai-assistant/components/AiAssistantPanel.test.ts` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ea1769188331994b5240e1885721)