### PR TITLE
Fix missing description when copying canvas elements

### DIFF
--- a/src/features/canvas/core/services/ClipboardService.test.ts
+++ b/src/features/canvas/core/services/ClipboardService.test.ts
@@ -3,6 +3,7 @@ import { ClipboardService } from './ClipboardService.ts';
 import { Scene } from '../scene/Scene.ts';
 import { StoryElement } from '../../elements/StoryElement.ts';
 import { TaskElement } from '../../elements/TaskElement.ts';
+import { GoalElement } from '../../elements/GoalElement.ts';
 
 describe('ClipboardService', () => {
   it('keeps copied task inside copied story after paste', () => {
@@ -51,5 +52,36 @@ describe('ClipboardService', () => {
 
     expect(pastedStory).toBeDefined();
     expect(pastedStory?.tasks).toHaveLength(0);
+  });
+
+  it('preserves description when copying and pasting tasks and goals', () => {
+    const clipboard = new ClipboardService();
+    const scene = new Scene();
+
+    const task = new TaskElement({
+      x: 100,
+      y: 100,
+      title: 'Task with description',
+      description: 'Task description should be preserved.',
+    });
+    const goal = new GoalElement({
+      x: 300,
+      y: 300,
+      title: 'Goal with description',
+      description: 'Goal description should be preserved.',
+    });
+
+    clipboard.copy([task, goal]);
+    const pasted = clipboard.paste(scene, { x: 700, y: 700 });
+
+    const pastedTask = pasted.find(
+      (element): element is TaskElement => element instanceof TaskElement
+    );
+    const pastedGoal = pasted.find(
+      (element): element is GoalElement => element instanceof GoalElement
+    );
+
+    expect(pastedTask?.description).toBe(task.description);
+    expect(pastedGoal?.description).toBe(goal.description);
   });
 });

--- a/src/features/canvas/elements/GoalElement.ts
+++ b/src/features/canvas/elements/GoalElement.ts
@@ -285,6 +285,7 @@ export class GoalElement extends PlanningElement {
       x: this.x,
       y: this.y,
       title: this.title,
+      description: this.description,
       status: this.status,
       priority: this.priority,
       scale: this.scale,

--- a/src/features/canvas/elements/TaskElement.ts
+++ b/src/features/canvas/elements/TaskElement.ts
@@ -245,6 +245,7 @@ export class TaskElement extends PlanningElement {
       x: this.x,
       y: this.y,
       title: this.title,
+      description: this.description,
       status: this.status,
       priority: this.priority,
       dueDate: this.dueDate,


### PR DESCRIPTION
### Motivation
- Copy/paste of canvas elements omitted the `description` field for some elements, causing user-entered descriptions to be lost after duplicating items.

### Description
- Include `description` when cloning `TaskElement` by updating `TaskElement.clone()` to pass `description` into the constructor (`src/features/canvas/elements/TaskElement.ts`).
- Include `description` when cloning `GoalElement` by updating `GoalElement.clone()` to pass `description` into the constructor (`src/features/canvas/elements/GoalElement.ts`).
- Add a regression test to `src/features/canvas/core/services/ClipboardService.test.ts` that verifies descriptions are preserved for pasted `TaskElement` and `GoalElement`.

### Testing
- Added unit test `preserves description when copying and pasting tasks and goals` to `src/features/canvas/core/services/ClipboardService.test.ts` which asserts `description` is preserved for pasted tasks and goals. 
- Attempted to run `npm run test -- src/features/canvas/core/services/ClipboardService.test.ts` but test execution failed in this environment because `vitest` was not available (`sh: 1: vitest: not found`).
- Attempted `npm install` to allow running tests but dependency installation did not complete in the environment, so automated test run could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2eca874ec833189cfc374a11ffa44)