### PR TITLE
Add UI architecture docs and standardize UI-lib agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,31 @@
 2. Reuse the existing component directly, or wrap/compose it if the screen needs a thin specialization.
 3. Add a new component only if no suitable primitive exists after that search.
 
+### UI Composition Standard
+
+- For any request about UI component structure, styling strategy, or templating, read `docs/UI-ARCHITECTURE.md` first.
+- Do not propose or perform a full UI paradigm rewrite (for example, migrating all UI creation to HTML templates) unless the user explicitly asks for a full migration plan.
+- Use this split by default:
+  - Tailwind config: design tokens and theme primitives.
+  - TypeScript UI modules: component variants, state-driven class composition, accessibility attributes, and behavior.
+  - HTML template helpers: only for mostly static markup blocks with low interaction complexity.
+- For interactive overlays, drag/drop surfaces, context menus, modal flows, and other lifecycle-heavy UI, prefer TypeScript component/controller patterns with explicit mount/unmount or open/close cleanup.
+
+### Styling Source Of Truth
+
+- Keep repeated or long utility-class compositions in typed UI-layer style maps (`classNames`, variant maps, component option maps), not inline in business logic branches.
+- Inline utility classes are acceptable for small one-off layout tweaks; avoid large repeated class strings across files.
+- Add new colors/spacing/scales to `tailwind.config.js` when they represent reusable design tokens; do not hardcode repeated design values in feature code.
+- Prefer extending `src/ui-lib/src` primitives and HUD variants over creating feature-local style dialects.
+
+### Reactive UI Boundaries
+
+- Treat UI reactivity as a hybrid architecture with explicit channel boundaries, as documented in `docs/UI-ARCHITECTURE.md`.
+- Keep canvas runtime reactivity (`Scene`/viewport/render-loop flows) isolated from module data-store reactivity.
+- Keep module domain/view-model state in typed module-local streams/stores.
+- Use global `window` custom events primarily for cross-module/app-shell integration, not as the default internal module state channel.
+- Avoid duplicate parallel channels for the same state transition; prefer one authoritative reactive path per concern.
+
 ### Script Conventions
 
 - `npm run start:stable` must remain a built app served through `vite preview`, but using Vite `development` mode config and env loading.
@@ -97,3 +122,17 @@
 - Owner: `src/features/canvas/ui`
 - Read first: `src/features/canvas/ui/AGENTS.md`
 - Expected result: extend `ContextMenu` through its own item model and renderers, keep its visuals separate from `SelectionActionMenu`, and move reusable context-menu primitives into HUD when needed.
+
+### Standardize UI Component Composition
+
+- Use when the request asks how to structure components, where styling rules should live, whether to use HTML templates, or how to unify UI patterns across modules.
+- Owner: `src/ui-lib` + `docs`
+- Read first: `docs/UI-ARCHITECTURE.md`
+- Expected result: keep a stable split between Tailwind tokens, TypeScript component recipes/behavior, and limited template usage for static fragments; avoid large-scale rewrites unless explicitly requested.
+
+### Align Reactive UI Channels
+
+- Use when the request discusses reactive behavior, event flow cleanup, stream-vs-event decisions, or module UI update consistency.
+- Owner: `docs` + feature modules
+- Read first: `docs/UI-ARCHITECTURE.md`
+- Expected result: preserve separated reactive channels by concern (canvas runtime, module stores, global integration, local control state), while reducing duplicate or ambiguous event pathways.

--- a/docs/UI-ARCHITECTURE.md
+++ b/docs/UI-ARCHITECTURE.md
@@ -1,0 +1,135 @@
+# UI Architecture Standard
+
+## Purpose
+
+This document defines the default UI implementation approach for Majom Canvas during alpha and beyond.
+It exists to reduce mixed patterns and keep component behavior, styling, and reuse decisions consistent across modules.
+
+## Core Principles
+
+1. **Evolve, do not rewrite**
+   - Prefer incremental standardization over full UI paradigm rewrites.
+   - Do not migrate the whole app to HTML templates unless explicitly requested.
+
+2. **UI-lib first**
+   - Reuse or extend primitives in `src/ui-lib/src` before adding feature-local primitives.
+
+3. **Behavior and lifecycle are first-class**
+   - For stateful interaction patterns (overlay, drag/drop, context menu, picker, modal), keep explicit lifecycle APIs (`mount/unmount`, `open/close`) and cleanup ownership in TypeScript.
+
+4. **Hybrid reactivity by design**
+   - The app intentionally uses multiple reactive channels because module responsibilities differ.
+   - Do not force canvas runtime, module data stores, and global integration signals into one universal mechanism.
+
+## Responsibility Split
+
+### Tailwind config (`tailwind.config.js`)
+
+Use for reusable design tokens and theme primitives:
+- colors
+- semantic aliases
+- reusable scale values
+
+Do not use Tailwind config as a replacement for component-level variant logic.
+
+### TypeScript UI modules (`src/ui-lib/src/**`, feature UI modules)
+
+Use for:
+- variant recipes (`tone`, `size`, `state`)
+- stateful class composition
+- accessibility attributes and interaction behavior
+- component/controller lifecycle management
+
+### Template helpers (optional, local)
+
+Use only for mostly static, low-interaction markup fragments.
+Avoid template-heavy patterns for lifecycle-rich or interaction-heavy components.
+
+## Reactive Model (Authoritative)
+
+### Channel A: Module state streams (RxJS stores/subjects)
+
+Use for domain and view-model state transitions.
+Example fit: kanban board state pipelines and state-to-view updates.
+
+### Channel B: Canvas runtime streams
+
+Use for high-frequency scene, focus/highlight, viewport, and render-loop triggers.
+This channel remains canvas-local and should not be reshaped into generic app store flows.
+
+### Channel C: Global integration events
+
+Use only for cross-module and app-shell integration boundaries.
+Keep payload contracts typed and explicit.
+
+### Channel D: Local UI control state
+
+Use imperative control APIs for local visual state (`setValue`, `setDisabled`, loading toggles, ARIA sync) when full re-render is unnecessary.
+
+## Reactive Boundaries: Keep Separate vs Unify
+
+### Keep separate
+
+- Canvas runtime reactivity and draw orchestration.
+- Module-level domain stores (for example kanban state stream).
+- Notification/toast stream as a cross-cutting UI feedback channel.
+
+### Unify
+
+- Naming and payload contracts across channels (`$` suffix for streams, typed payload guards).
+- Cleanup discipline for subscriptions/listeners.
+- Policy for choosing granular DOM patching vs full section re-render.
+
+### Reduce/avoid
+
+- Excess use of global `window` custom events for purely internal module UI flows.
+- Duplicated event pathways that represent the same state transition in parallel.
+
+## Component Layers
+
+### Layer A: Primitive Components
+
+Small reusable UI building blocks with typed options.
+
+Examples:
+- button/input/select/surface primitives
+- HUD primitives in `src/ui-lib/src/hud`
+
+### Layer B: Composite Components
+
+Compositions of primitives for a specific feature use-case, while still keeping UI logic mostly local and testable.
+
+### Layer C: UI Controllers
+
+Lifecycle-heavy orchestrators that own subscriptions, DOM mount points, event listeners, and cleanup.
+
+## Styling Rules
+
+1. Keep repeated/long utility class sets in typed style maps (`classNames`, variant maps, tone-size maps).
+2. Allow small one-off inline classes for local layout adjustments.
+3. Avoid duplicating large utility strings across files.
+4. If a repeated value is design-system-level, add it as a Tailwind token first.
+
+## Decision Matrix
+
+- **Need reusable visual primitive?** → `src/ui-lib/src` (prefer HUD-style composition).
+- **Need feature-specific UI with light behavior?** → feature composite built from ui-lib primitives.
+- **Need lifecycle-heavy interaction flow?** → controller class with explicit cleanup.
+- **Need static section markup?** → optional template helper (local and minimal).
+- **Need module domain/view state flow?** → RxJS store/subject channel.
+- **Need canvas frame/runtime updates?** → canvas-local scene/panzoom/render channels.
+- **Need app-shell or cross-module signal?** → typed global integration event.
+
+## Migration Guidance (Alpha)
+
+1. Standardize new code first; avoid broad rewrites of stable code paths.
+2. Consolidate duplicated style recipes into ui-lib as features evolve.
+3. Move high-value repeated patterns first (buttons, inputs, dropdown surfaces, form messaging).
+4. Keep canvas-specific interaction systems feature-local when they depend on canvas scene state.
+5. Convert internal module `window` events to module-local typed channels when practical; keep global events only at integration boundaries.
+6. Prefer one reactive channel per concern; avoid parallel duplicate channels for the same concern.
+
+## Related Docs
+
+- `AGENTS.md` (global assistant rules and scenario index)
+- `docs/CANVAS-UI-TO-UI-LIB-ANALYSIS.md` (canvas-to-ui-lib consolidation analysis)

--- a/src/ui-lib/AGENTS.md
+++ b/src/ui-lib/AGENTS.md
@@ -1,0 +1,42 @@
+# UI-Lib Rules
+
+## Scope
+
+These rules apply to the entire `src/ui-lib` tree.
+
+## Read First
+
+- `docs/UI-ARCHITECTURE.md`
+- root `AGENTS.md`
+
+## Implementation Rules
+
+1. **Primitive-first reuse**
+   - Before adding a new primitive, check existing components under:
+     - `src/ui-lib/src/components`
+     - `src/ui-lib/src/hud`
+
+2. **Single source of truth**
+   - If a primitive behavior already exists in HUD, extend/converge instead of creating a parallel implementation.
+   - Prefer compatibility adapters/re-exports over duplicate logic.
+
+3. **TypeScript responsibility**
+   - Keep variant maps, state transitions, and interaction behavior in TypeScript modules.
+   - Do not move lifecycle-heavy interaction behavior into static HTML template strings.
+   - For local control reactivity, prefer explicit typed APIs (`setValue`, `setDisabled`, loading-state setters) over ad-hoc global events.
+
+4. **Styling responsibility**
+   - Keep repeated style combinations in typed style maps.
+   - Inline utility strings are acceptable for small, one-off composition.
+   - Promote reusable visual values to Tailwind tokens when they become cross-component design primitives.
+
+5. **Feature boundary**
+   - Keep ui-lib primitives domain-neutral.
+   - Canvas-specific behavior belongs in `src/features/canvas/ui` unless it is clearly reusable across features.
+   - Do not use ui-lib primitives as a transport layer for feature-module global custom-event wiring.
+
+## Expected Outcome
+
+- Shared primitives remain consistent, typed, and reusable.
+- Feature modules compose ui-lib primitives instead of reinventing them.
+- Styling strategy remains predictable: Tailwind tokens + TypeScript variant composition.


### PR DESCRIPTION
### Motivation

- Establish a consistent UI implementation standard to encourage reuse of `src/ui-lib` and avoid ad-hoc UI rewrites.
- Clarify reactive channel boundaries and lifecycle expectations for interactive and canvas/runtime components.
- Provide concrete guidance on styling, Tailwind tokens, template usage, and where behavior should live (TypeScript vs templates).

### Description

- Extended the root `AGENTS.md` with a `UI Composition Standard`, `Styling Source Of Truth`, `Reactive UI Boundaries`, and related scenario entries to guide assistant-driven UI work.
- Added `docs/UI-ARCHITECTURE.md` as a new comprehensive reference describing core principles, the Tailwind/TypeScript/template responsibility split, reactive channels, component layers, styling rules, decision matrix, and migration guidance.
- Added `src/ui-lib/AGENTS.md` to capture `ui-lib`-specific rules (primitive-first reuse, single source of truth, TypeScript responsibility, styling responsibility, and feature-boundary guidance).

### Testing

- No automated tests were added or modified for this documentation-only change.
- This change did not run unit or integration tests locally because it only updates documentation files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3b5e1fa7c8331972dbe9068a9f96d)