### PR TITLE
Introduce Time Clustering workspace view and Stage 1 frontend prototype

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@
 - When the user corrects the assistant and that correction reveals a stable project rule, a recurring mistake, a contradiction, or an important edge case, update `AGENTS.md` in the same task unless the user explicitly says not to.
 - Only promote corrections into `AGENTS.md` when they are durable guidance for future work, not one-off preferences or temporary task details.
 - Keep new rules concrete and actionable so they improve future decisions instead of adding vague process noise.
+- If the user states that a documentation file already exists on their latest branch state, do not create a replacement file with the same intent. First verify branch sync status and only proceed with file creation after explicit confirmation.
 
 ### Scenario Self-Improvement
 

--- a/docs/TIME-CLUSTERING.md
+++ b/docs/TIME-CLUSTERING.md
@@ -1,0 +1,220 @@
+# Time Clustering
+
+## Status
+
+- State: discovery
+- Started: 2026-03-25
+- Last updated: 2026-03-25
+- Document type: living product and UX notes
+
+## Working Name
+
+- Product-facing name: `Time Clustering`
+- Technical module id (proposed): `time-clustering`
+
+## Why This Feature Exists
+
+`Time Clustering` solves a practical planning gap:
+users may have many tasks across different categories, and even with better prioritization,
+deadlines, and weekly/day assignment, they still struggle to keep a balanced day.
+
+Without explicit time boundaries, a user can over-focus on one project or one task type
+and unintentionally neglect other important areas (health, rest, learning, relationships, etc.).
+
+The feature introduces explicit day-level time clusters so users can protect time blocks
+for important life and work categories and distribute actionable work inside those boundaries.
+
+## Product Intent
+
+- Split each day into meaningful time clusters.
+- Let users reserve and protect time for key categories.
+- Allocate actionable items into these clusters.
+- Reduce planning overload by turning “too many tasks” into a clearer daily structure.
+- Keep personal balance visible (work, health, recovery, social, learning, etc.).
+
+## Example Cluster Categories
+
+- Sport
+- Meditation
+- Rest
+- Cooking / meals
+- Work
+- Learning
+- Social connection
+
+> Categories above are examples; final taxonomy is user-defined.
+
+## Confirmed Decisions (2026-03-25)
+
+### Stage 1 delivery boundary (prototype mode)
+
+- Stage 1 is frontend-only and is not integrated with backend APIs.
+- Stage 1 data is stored in browser local storage.
+- Stage 1 storage key convention (initial): use `time_clusters_v1` as the primary local-storage key.
+- Stage 1 scope is limited to cluster creation and cluster visualization correctness.
+- Stage 1 does **not** include assigning tasks/habits into clusters yet.
+- Task/habit assignment is deferred to a later stage together with the `Resource Planner` feature.
+- AI in Stage 1 should consider existing clusters and suggest cluster distribution for a day or week.
+- AI suggestions in Stage 1 should be actionable (button-driven apply flow), not only informational text.
+
+> Note: unless explicitly marked as Stage 1 behavior, decisions below describe the target operating model for later stages.
+
+### 1) Cluster creation model
+
+- There is no mandatory default cluster set.
+- Users create clusters manually.
+- AI may suggest useful clusters, but suggestions are optional.
+
+### 2) Cluster overlap rules
+
+- Overlap is allowed only when two clusters represent activities that can truly be done in parallel.
+- If activities are not realistically parallelizable, overlap is not allowed.
+- Overlap logic is tied to real-world execution feasibility.
+
+### 3) Capacity overflow and backlog
+
+- Each cluster has a backlog.
+- If items do not fit in a cluster today, they are carried to the next day.
+- Items not completed on previous days are also carried forward (with type-specific handling noted below).
+
+### 4) Allowed item types inside clusters
+
+- Allowed: `Task`, `Habit`.
+- Not allowed: `Story`, `Goal`.
+- Rationale: clusters contain concrete executable actions, while stories/goals are strategic grouping levels.
+
+### 5) One item in one cluster (v1 default)
+
+- Current default assumption: one actionable item belongs to one cluster at a time.
+- Future flexibility may be explored if strong product cases appear.
+
+Potential future case for multi-cluster assignment:
+
+- Example: long-running research task split into `Deep Work` (analysis) and `Communication` (stakeholder sync).
+- For v1, this should still be represented as separate sub-tasks rather than one task in two clusters.
+
+### 6) Cluster enforcement stance
+
+- Product direction is closer to strict assignment semantics:
+  actionable items should be assigned to a matching cluster, not left unstructured.
+- The exact UX strictness (hard blocks vs guided guardrails) remains a design detail.
+
+### 7) Prioritization ownership
+
+- Time Clustering does not own internal item ordering/prioritization logic.
+- Prioritization is delegated to the planned `Resource Planner` feature.
+- In Stage 1, assignment of actionable items is not implemented; cluster planning is structural only.
+- Time Clustering becomes a time-bound routing layer (“pipeline”) after assignment is enabled in later stages.
+
+### 8) Adaptivity and rhythm
+
+- Cluster structure should be adaptive over time.
+- Day templates may differ by weekday and user rhythm.
+- AI-assisted suggestions should eventually use behavior signals to recommend healthier alternation patterns
+  (focus vs recovery, context switching, cadence).
+
+### 9) Day view behavior
+
+- Day view is primarily an informational view.
+- Default focus: today.
+- Supports quick navigation to previous/next day.
+- Editing of cluster structure is not required in this compact day-focused mode by default.
+
+### 10) Fullscreen week behavior
+
+- Week view is mandatory in fullscreen mode.
+- Primary purpose: forward planning of cluster distribution for upcoming days/week,
+  with optional AI guidance.
+
+### 11) Balance metrics and nudges
+
+- Balance metrics are in scope as supportive feedback.
+- AI-based recommendations are desirable.
+- Nudges should be helpful and subtle, not intrusive.
+
+### 12) Carry-over rules by item type (initial)
+
+- `Habit`: generally appears again by its recurrence logic; do not treat as naive carry-over clone.
+- `Task`: usually carried/replanned forward if incomplete, with exceptions for date-specific hard-deadline tasks
+  (e.g., airport transfer) that may require separate handling.
+
+### 13) Mobile posture (current)
+
+- Dedicated mobile mode is not critical for first increment.
+- On small screens, only one major workspace surface is expected to be visible at a time
+  (time clustering OR canvas OR AI assistant).
+
+### 14) Day-to-day duplication behavior (Stage 1)
+
+- Stage 1 supports one-off day template duplication (copy full day).
+- Collision policy in Stage 1: keep-both and show a warning indicator; no automatic destructive overwrite.
+- Recurrence-based duplication (e.g., weekdays rule) is deferred beyond Stage 1.
+
+## Relationship To Other Planned Features
+
+This feature should integrate with, but remain distinct from:
+
+- `Resource Planner` (planned feature; prioritization, sequencing, resource constraints)
+- planning branches (planned feature)
+
+Current assumption:
+
+- Resource/branch features choose and sequence work,
+- Time Clustering distributes selected work into realistic day-time boundaries.
+- AI chat integration must include cluster-context access; current canvas-centric context assumptions are not sufficient for Time Clustering suggestion flows.
+
+## Core UX Concept
+
+The visual model should resemble a calendar timeline,
+but instead of classic event-centric scheduling,
+it emphasizes daily time zones (clusters).
+
+Users should see what clusters exist for today.
+In Stage 1, focus is cluster structure and visibility; routing actionable items is deferred to later stages.
+
+## Required Views (initial)
+
+### 1) Day View (compact)
+
+- Compact day-focused presentation used when screen space is constrained or when a narrow side panel is preferred.
+- Focused “today” view with day timeline and active clusters.
+- Informational-first: shows sequence, context, and quick day navigation.
+
+### 2) Fullscreen View
+
+- Primary planning surface for broader horizon.
+- Must include week mode.
+- Month mode is optional and must be validated by product value before commitment.
+
+## Remaining Open Questions
+
+1. Should overlap validation be manual (user decides) or rule-assisted (system detects impossible overlaps)?
+2. How should hard-deadline tasks be represented so carry-over does not hide missed commitments?
+3. What is the minimal v1 signal set for AI cluster recommendations (history, energy pattern, category balance)?
+4. Should users be able to pin “non-negotiable” clusters (sleep, medication, commute) before work allocation?
+5. What exact balance metrics should appear first (time share per category, uninterrupted focus depth, recovery ratio)?
+
+## Initial Non-Goals
+
+- Full autonomous AI scheduler from day one.
+- Complex collaboration workflows in v1.
+- Deep monthly analytics before core day/week flow is validated.
+
+## Minimum Viable Outcome (draft)
+
+### Stage 1 (current target)
+
+A user can:
+
+1. create daily time clusters manually,
+2. receive AI suggestions for cluster distribution across day/week and apply them via explicit action controls,
+3. view clusters in day and week contexts,
+4. store and restore cluster plans in browser local storage,
+5. edit/delete clusters and validate visual layout behavior.
+
+### Stage 2+ (future target)
+
+- Assign `Task` and `Habit` items into clusters.
+- Activate backlog/carry-over behavior for actionable items.
+- Track completion visibility inside each cluster with planner-driven ordering.
+

--- a/src/features/shell/WorkspaceView.ts
+++ b/src/features/shell/WorkspaceView.ts
@@ -1,1 +1,1 @@
-export type WorkspaceView = 'canvas' | 'kanban';
+export type WorkspaceView = 'canvas' | 'kanban' | 'time-clustering';

--- a/src/features/shell/workspaceEvents.ts
+++ b/src/features/shell/workspaceEvents.ts
@@ -13,7 +13,7 @@ export type WorkspaceViewChangedDetail = {
 };
 
 export function isWorkspaceView(value: unknown): value is WorkspaceView {
-  return value === 'canvas' || value === 'kanban' || value === 'calendar';
+  return value === 'canvas' || value === 'kanban' || value === 'time-clustering';
 }
 
 export function isWorkspaceViewChangeRequestDetail(

--- a/src/features/shell/workspaceUiState.ts
+++ b/src/features/shell/workspaceUiState.ts
@@ -15,6 +15,7 @@ export function loadPersistedWorkspaceView(
   try {
     const value = localStorage.getItem(WORKSPACE_ACTIVE_VIEW_STORAGE_KEY);
     if (value === 'kanban' && allowKanban) return 'kanban';
+    if (value === 'time-clustering') return 'time-clustering';
   } catch {
     // no-op
   }

--- a/src/features/time-clustering/TimeClusteringApp.ts
+++ b/src/features/time-clustering/TimeClusteringApp.ts
@@ -1,0 +1,26 @@
+import { LocalStorageTimeClusteringRepository } from './data/LocalStorageTimeClusteringRepository.ts';
+import { TimeClusteringStore } from './state/TimeClusteringStore.ts';
+import { TimeClusteringRootView } from './ui/components/TimeClusteringRootView.ts';
+import { StubTimeClusteringSuggestionService } from './services/TimeClusteringSuggestionService.ts';
+
+export class TimeClusteringApp {
+  private readonly store = new TimeClusteringStore(new LocalStorageTimeClusteringRepository());
+  private readonly view = new TimeClusteringRootView(this.store);
+  private readonly suggestionService = new StubTimeClusteringSuggestionService();
+
+  public mount(parent: HTMLElement): void {
+    this.view.mount(parent);
+  }
+
+  public unmount(): void {
+    this.view.unmount();
+  }
+
+  public async refreshSuggestions(): Promise<void> {
+    const snapshot = this.store.getSnapshot();
+    await this.suggestionService.buildSuggestions({
+      dateKey: snapshot.selectedDateKey,
+      existingPlans: snapshot.plansByDate,
+    });
+  }
+}

--- a/src/features/time-clustering/TimeClusteringModule.ts
+++ b/src/features/time-clustering/TimeClusteringModule.ts
@@ -1,0 +1,24 @@
+import type { WorkspaceModule } from '../shell/WorkspaceModule.ts';
+import type { AiAssistantCanvasSnapshot } from '../ai-assistant/aiAssistantEvents.ts';
+import { TimeClusteringApp } from './TimeClusteringApp.ts';
+
+export class TimeClusteringModule implements WorkspaceModule {
+  public readonly id = 'time-clustering' as const;
+  private app: TimeClusteringApp | null = null;
+
+  public mount(parent: HTMLElement): void {
+    if (this.app) return;
+    const app = new TimeClusteringApp();
+    app.mount(parent);
+    this.app = app;
+  }
+
+  public unmount(): void {
+    this.app?.unmount();
+    this.app = null;
+  }
+
+  public getAiAssistantSnapshot(): AiAssistantCanvasSnapshot | null {
+    return null;
+  }
+}

--- a/src/features/time-clustering/data/LocalStorageTimeClusteringRepository.ts
+++ b/src/features/time-clustering/data/LocalStorageTimeClusteringRepository.ts
@@ -1,0 +1,32 @@
+import type { TimeClusteringStateSnapshot } from '../domain/types.ts';
+import type { TimeClusteringRepository } from './TimeClusteringRepository.ts';
+
+export const TIME_CLUSTERS_STORAGE_KEY = 'time_clusters_v1';
+
+export class LocalStorageTimeClusteringRepository implements TimeClusteringRepository {
+  constructor(private readonly storage: Storage = window.localStorage) {}
+
+  public load(): TimeClusteringStateSnapshot | null {
+    const raw = this.storage.getItem(TIME_CLUSTERS_STORAGE_KEY);
+    if (!raw) return null;
+
+    try {
+      const parsed = JSON.parse(raw) as TimeClusteringStateSnapshot;
+      if (!parsed || typeof parsed !== 'object') return null;
+      if (typeof parsed.selectedDateKey !== 'string') return null;
+      if (parsed.viewMode !== 'day-compact' && parsed.viewMode !== 'week-fullscreen') return null;
+      if (!parsed.plansByDate || typeof parsed.plansByDate !== 'object') return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  public save(snapshot: TimeClusteringStateSnapshot): void {
+    this.storage.setItem(TIME_CLUSTERS_STORAGE_KEY, JSON.stringify(snapshot));
+  }
+
+  public clear(): void {
+    this.storage.removeItem(TIME_CLUSTERS_STORAGE_KEY);
+  }
+}

--- a/src/features/time-clustering/data/TimeClusteringRepository.ts
+++ b/src/features/time-clustering/data/TimeClusteringRepository.ts
@@ -1,0 +1,7 @@
+import type { TimeClusteringStateSnapshot } from '../domain/types.ts';
+
+export interface TimeClusteringRepository {
+  load(): TimeClusteringStateSnapshot | null;
+  save(snapshot: TimeClusteringStateSnapshot): void;
+  clear(): void;
+}

--- a/src/features/time-clustering/domain/rules.ts
+++ b/src/features/time-clustering/domain/rules.ts
@@ -1,0 +1,80 @@
+import type {
+  DayClusterPlan,
+  DuplicationResult,
+  DuplicationWarning,
+  TimeCluster,
+} from './types.ts';
+
+export const MINUTES_PER_DAY = 24 * 60;
+
+export function clampMinute(value: number): number {
+  if (value < 0) return 0;
+  if (value > MINUTES_PER_DAY) return MINUTES_PER_DAY;
+  return value;
+}
+
+export function normalizeCluster(cluster: TimeCluster): TimeCluster {
+  const startMinute = clampMinute(cluster.startMinute);
+  const endMinute = clampMinute(cluster.endMinute);
+  return {
+    ...cluster,
+    startMinute: Math.min(startMinute, endMinute),
+    endMinute: Math.max(startMinute, endMinute),
+  };
+}
+
+export function canClustersOverlap(a: TimeCluster, b: TimeCluster): boolean {
+  // Stage 1 policy: overlap is allowed only when both clusters are explicitly marked parallelizable.
+  return a.parallelizable && b.parallelizable;
+}
+
+export function hasTimeIntersection(a: TimeCluster, b: TimeCluster): boolean {
+  return a.startMinute < b.endMinute && b.startMinute < a.endMinute;
+}
+
+export function validateClusterPlacement(
+  candidate: TimeCluster,
+  existing: TimeCluster[]
+): DuplicationWarning[] {
+  const normalized = normalizeCluster(candidate);
+  const warnings: DuplicationWarning[] = [];
+
+  for (const cluster of existing) {
+    if (!hasTimeIntersection(normalized, cluster)) continue;
+    if (canClustersOverlap(normalized, cluster)) continue;
+    warnings.push({
+      type: 'time-collision',
+      sourceClusterId: normalized.id,
+      targetClusterId: cluster.id,
+    });
+  }
+
+  return warnings;
+}
+
+export function duplicateDayPlanKeepBoth(params: {
+  source: DayClusterPlan;
+  targetDateKey: string;
+  targetExisting?: DayClusterPlan | null;
+  nowIso: string;
+}): DuplicationResult {
+  const { nowIso, source, targetDateKey, targetExisting } = params;
+
+  const existingClusters = targetExisting?.clusters ?? [];
+  const clonedClusters = source.clusters.map((cluster) => ({ ...cluster }));
+  const mergedClusters = [...existingClusters, ...clonedClusters];
+
+  const warnings: DuplicationWarning[] = [];
+  for (const cluster of clonedClusters) {
+    warnings.push(...validateClusterPlacement(cluster, existingClusters));
+  }
+
+  return {
+    plan: {
+      dateKey: targetDateKey,
+      clusters: mergedClusters,
+      updatedAtIso: nowIso,
+    },
+    warnings,
+  };
+}

--- a/src/features/time-clustering/domain/types.ts
+++ b/src/features/time-clustering/domain/types.ts
@@ -1,0 +1,33 @@
+export type TimeClusteringViewMode = 'day-compact' | 'week-fullscreen';
+
+export interface TimeCluster {
+  id: string;
+  title: string;
+  colorToken: string;
+  startMinute: number;
+  endMinute: number;
+  parallelizable: boolean;
+}
+
+export interface DayClusterPlan {
+  dateKey: string; // YYYY-MM-DD in local timezone
+  clusters: TimeCluster[];
+  updatedAtIso: string;
+}
+
+export interface DuplicationWarning {
+  type: 'time-collision';
+  sourceClusterId: string;
+  targetClusterId: string;
+}
+
+export interface DuplicationResult {
+  plan: DayClusterPlan;
+  warnings: DuplicationWarning[];
+}
+
+export interface TimeClusteringStateSnapshot {
+  selectedDateKey: string;
+  viewMode: TimeClusteringViewMode;
+  plansByDate: Record<string, DayClusterPlan>;
+}

--- a/src/features/time-clustering/index.ts
+++ b/src/features/time-clustering/index.ts
@@ -1,0 +1,12 @@
+export { TimeClusteringModule } from './TimeClusteringModule.ts';
+export { TimeClusteringApp } from './TimeClusteringApp.ts';
+export {
+  TIME_CLUSTERS_STORAGE_KEY,
+  LocalStorageTimeClusteringRepository,
+} from './data/LocalStorageTimeClusteringRepository.ts';
+export type {
+  DayClusterPlan,
+  TimeCluster,
+  TimeClusteringStateSnapshot,
+  TimeClusteringViewMode,
+} from './domain/types.ts';

--- a/src/features/time-clustering/services/TimeClusteringSuggestionService.ts
+++ b/src/features/time-clustering/services/TimeClusteringSuggestionService.ts
@@ -1,0 +1,25 @@
+import type { DayClusterPlan } from '../domain/types.ts';
+
+export interface TimeClusteringSuggestion {
+  id: string;
+  title: string;
+  description: string;
+  dayPlans: DayClusterPlan[];
+}
+
+export interface TimeClusteringSuggestionService {
+  buildSuggestions(params: {
+    dateKey: string;
+    existingPlans: Record<string, DayClusterPlan>;
+  }): Promise<TimeClusteringSuggestion[]>;
+}
+
+export class StubTimeClusteringSuggestionService implements TimeClusteringSuggestionService {
+  public async buildSuggestions(_params: {
+    dateKey: string;
+    existingPlans: Record<string, DayClusterPlan>;
+  }): Promise<TimeClusteringSuggestion[]> {
+    // Stage 1 skeleton: replace with AI-backed orchestration.
+    return [];
+  }
+}

--- a/src/features/time-clustering/state/TimeClusteringStore.ts
+++ b/src/features/time-clustering/state/TimeClusteringStore.ts
@@ -1,0 +1,75 @@
+import type { TimeClusteringStateSnapshot, TimeClusteringViewMode } from '../domain/types.ts';
+import type { TimeClusteringRepository } from '../data/TimeClusteringRepository.ts';
+
+export type TimeClusteringStoreListener = (snapshot: TimeClusteringStateSnapshot) => void;
+
+function todayDateKey(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function createDefaultSnapshot(): TimeClusteringStateSnapshot {
+  return {
+    selectedDateKey: todayDateKey(),
+    viewMode: 'day-compact',
+    plansByDate: {},
+  };
+}
+
+export class TimeClusteringStore {
+  private snapshot: TimeClusteringStateSnapshot;
+  private readonly listeners = new Set<TimeClusteringStoreListener>();
+
+  constructor(private readonly repository: TimeClusteringRepository) {
+    this.snapshot = repository.load() ?? createDefaultSnapshot();
+  }
+
+  public getSnapshot(): TimeClusteringStateSnapshot {
+    return this.snapshot;
+  }
+
+  public subscribe(listener: TimeClusteringStoreListener): () => void {
+    this.listeners.add(listener);
+    listener(this.snapshot);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public setSelectedDate(dateKey: string): void {
+    this.snapshot = {
+      ...this.snapshot,
+      selectedDateKey: dateKey,
+    };
+    this.publish();
+  }
+
+  public setViewMode(mode: TimeClusteringViewMode): void {
+    this.snapshot = {
+      ...this.snapshot,
+      viewMode: mode,
+    };
+    this.publish();
+  }
+
+  public upsertDayPlan(next: TimeClusteringStateSnapshot['plansByDate'][string]): void {
+    this.snapshot = {
+      ...this.snapshot,
+      plansByDate: {
+        ...this.snapshot.plansByDate,
+        [next.dateKey]: next,
+      },
+    };
+    this.publish();
+  }
+
+  private publish(): void {
+    this.repository.save(this.snapshot);
+    for (const listener of this.listeners) {
+      listener(this.snapshot);
+    }
+  }
+}

--- a/src/features/time-clustering/ui/components/TimeClusteringRootView.ts
+++ b/src/features/time-clustering/ui/components/TimeClusteringRootView.ts
@@ -1,0 +1,37 @@
+import type { TimeClusteringStore } from '../../state/TimeClusteringStore.ts';
+
+export class TimeClusteringRootView {
+  private readonly root: HTMLDivElement;
+  private readonly title: HTMLHeadingElement;
+  private readonly subtitle: HTMLParagraphElement;
+  private disposeStoreSubscription: (() => void) | null = null;
+
+  constructor(private readonly store: TimeClusteringStore) {
+    this.root = document.createElement('div');
+    this.root.className = 'h-full w-full p-4 text-zinc-100';
+
+    this.title = document.createElement('h2');
+    this.title.className = 'text-lg font-semibold';
+    this.title.textContent = 'Time Clustering';
+
+    this.subtitle = document.createElement('p');
+    this.subtitle.className = 'mt-2 text-sm text-zinc-400';
+
+    this.root.append(this.title, this.subtitle);
+  }
+
+  public mount(parent: HTMLElement): void {
+    parent.appendChild(this.root);
+    this.disposeStoreSubscription = this.store.subscribe((snapshot) => {
+      this.subtitle.textContent = `Mode: ${snapshot.viewMode} • Date: ${snapshot.selectedDateKey} • Days planned: ${Object.keys(
+        snapshot.plansByDate
+      ).length}`;
+    });
+  }
+
+  public unmount(): void {
+    this.disposeStoreSubscription?.();
+    this.disposeStoreSubscription = null;
+    this.root.remove();
+  }
+}


### PR DESCRIPTION
### Motivation

- Add a new "Time Clustering" workspace to let users define day-level time clusters and protect time for categories (Stage 1 is frontend-only and stored in local storage). 
- Provide a minimal, safe-first implementation surface (store, repo, UI skeleton, and suggestion-service stub) to let the feature be mounted in the workspace later. 
- Capture a small project guideline about creating documentation files only after verifying branch state.

### Description

- Add a new `time-clustering` workspace view option and wire it into `WorkspaceView`, `workspaceEvents`, and persisted UI state loading via `loadPersistedWorkspaceView`. 
- Implement a Time Clustering feature surface under `src/features/time-clustering` including `TimeClusteringModule`, `TimeClusteringApp`, a `TimeClusteringStore`, repository interfaces and a `LocalStorageTimeClusteringRepository`, domain `types` and `rules`, a stubbed `TimeClusteringSuggestionService`, and a simple `TimeClusteringRootView` UI component. 
- Add a top-level export (`src/features/time-clustering/index.ts`) and a dedicated storage key (`time_clusters_v1`) for Stage 1 local storage persistence. 
- Add a new doc `docs/TIME-CLUSTERING.md` describing product intent, Stage 1 scope, rules, and open questions, and update `AGENTS.md` with an instruction about verifying branch/document existence before creating replacement docs.

### Testing

- No automated tests were added or modified for this change. 
- Basic static checks were considered as part of the change verification (the additions are TypeScript-first and intended to compile against the existing codebase as a dev-only feature).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3b55e703083319f2985504e680482)