### PR TITLE
Add Time Clustering Stage 1 frontend, reactive store, and runtime wiring

### DIFF
--- a/docs/TIME-CLUSTERING.md
+++ b/docs/TIME-CLUSTERING.md
@@ -2,10 +2,10 @@
 
 ## Status
 
-- State: discovery
+- State: discovery → implementation-ready (Stage 1 frontend)
 - Started: 2026-03-25
 - Last updated: 2026-03-25
-- Document type: living product and UX notes
+- Document type: living product + architecture spec
 
 ## Working Name
 
@@ -14,207 +14,249 @@
 
 ## Why This Feature Exists
 
-`Time Clustering` solves a practical planning gap:
-users may have many tasks across different categories, and even with better prioritization,
-deadlines, and weekly/day assignment, they still struggle to keep a balanced day.
+`Time Clustering` addresses a day-planning gap: users can have prioritized work but still overload one category and neglect others when time boundaries are implicit.
 
-Without explicit time boundaries, a user can over-focus on one project or one task type
-and unintentionally neglect other important areas (health, rest, learning, relationships, etc.).
+The feature introduces explicit day-level time clusters (focused time zones) so users can protect capacity for meaningful categories and keep a balanced daily rhythm.
 
-The feature introduces explicit day-level time clusters so users can protect time blocks
-for important life and work categories and distribute actionable work inside those boundaries.
+## Stage 1 Scope (Confirmed)
+
+Stage 1 is intentionally narrow and frontend-only:
+
+- No backend APIs, no server persistence.
+- Local persistence only, primary key: `time_clusters_v1`.
+- User can create/edit/delete clusters and duplicate a full day as a one-off action.
+- Day + week visualization is in scope.
+- AI suggestions are **action-based** (structured suggestion actions + explicit Apply), not text-only advice.
+- **No assignment of `Task`/`Habit` into clusters in Stage 1.**
+- Resource Planner integration is conceptual only in Stage 1 (contract-aligned boundaries, no planner execution).
+
+### Stage 1 Duplication Policy (Confirmed)
+
+- Supported: one-off “copy full day” duplication.
+- Collision policy: keep-both + warning (no destructive overwrite).
+- Recurrence rules (e.g., weekday templates) are deferred.
 
 ## Product Intent
 
 - Split each day into meaningful time clusters.
-- Let users reserve and protect time for key categories.
-- Allocate actionable items into these clusters.
-- Reduce planning overload by turning “too many tasks” into a clearer daily structure.
-- Keep personal balance visible (work, health, recovery, social, learning, etc.).
+- Keep balance visible across work, health, recovery, social, learning, and similar categories.
+- Provide clear day/week structure first, before item routing and planner-level optimization.
+- Establish an architecture-compatible base for future Resource Planner integration.
 
-## Example Cluster Categories
+## Architectural Alignment (UI + Reactivity)
 
-- Sport
-- Meditation
-- Rest
-- Cooking / meals
-- Work
-- Learning
-- Social connection
+This section aligns Time Clustering with `docs/UI-ARCHITECTURE.md` and module boundary rules.
 
-> Categories above are examples; final taxonomy is user-defined.
+### 1) Domain Layer
 
-## Confirmed Decisions (2026-03-25)
+Owns core business meaning (framework-agnostic types/rules):
 
-### Stage 1 delivery boundary (prototype mode)
+- `TimeCluster` (id, day, start/end, category label, optional metadata).
+- `DayClusterPlan` (clusters for a day + warnings/metadata).
+- `WeekClusterPlan` (projection/aggregation for week view).
+- `ClusterDuplicationResult` (created entries + collision warnings).
+- Validation rules:
+  - cluster time ranges are valid,
+  - collisions are detected and preserved (keep-both in Stage 1),
+  - overlap semantics are recorded but not auto-resolved by backend logic in Stage 1.
 
-- Stage 1 is frontend-only and is not integrated with backend APIs.
-- Stage 1 data is stored in browser local storage.
-- Stage 1 storage key convention (initial): use `time_clusters_v1` as the primary local-storage key.
-- Stage 1 scope is limited to cluster creation and cluster visualization correctness.
-- Stage 1 does **not** include assigning tasks/habits into clusters yet.
-- Task/habit assignment is deferred to a later stage together with the `Resource Planner` feature.
-- AI in Stage 1 should consider existing clusters and suggest cluster distribution for a day or week.
-- AI suggestions in Stage 1 should be actionable (button-driven apply flow), not only informational text.
+Domain layer does **not** know about DOM, localStorage APIs, or global window events.
 
-> Note: unless explicitly marked as Stage 1 behavior, decisions below describe the target operating model for later stages.
+### 2) Data Layer
 
-### 1) Cluster creation model
+Owns persistence adapters and serialization:
 
-- There is no mandatory default cluster set.
-- Users create clusters manually.
-- AI may suggest useful clusters, but suggestions are optional.
+- `TimeClusteringRepository` interface (load/save/snapshot).
+- Stage 1 adapter: localStorage-backed repository using `time_clusters_v1`.
+- Versioned serialization contract for future migration (`v1` payload).
 
-### 2) Cluster overlap rules
+Data layer responsibilities:
 
-- Overlap is allowed only when two clusters represent activities that can truly be done in parallel.
-- If activities are not realistically parallelizable, overlap is not allowed.
-- Overlap logic is tied to real-world execution feasibility.
+- read/write whole module snapshot,
+- return parse/validation failures as typed errors,
+- remain replaceable by future API-backed adapter without changing domain contracts.
 
-### 3) Capacity overflow and backlog
+### 3) State-Application Layer (Module state streams)
 
-- Each cluster has a backlog.
-- If items do not fit in a cluster today, they are carried to the next day.
-- Items not completed on previous days are also carried forward (with type-specific handling noted below).
+Owns authoritative module state transitions via typed module-local streams (RxJS store/subjects):
 
-### 4) Allowed item types inside clusters
+- `timeClusteringState$` is the **single source of truth** for module domain/view-model state.
+- Commands/actions reduce into next snapshot (immutable update style).
+- Derived selectors/streams provide day view model, week view model, warnings, and pending AI actions.
 
-- Allowed: `Task`, `Habit`.
-- Not allowed: `Story`, `Goal`.
-- Rationale: clusters contain concrete executable actions, while stories/goals are strategic grouping levels.
+Examples of typed actions (Stage 1):
 
-### 5) One item in one cluster (v1 default)
+- `initializeFromStorage`
+- `createCluster`
+- `updateCluster`
+- `deleteCluster`
+- `duplicateDayOneOff`
+- `applyAiSuggestionAction`
+- `setActiveDay`
+- `setWeekAnchor`
 
-- Current default assumption: one actionable item belongs to one cluster at a time.
-- Future flexibility may be explored if strong product cases appear.
+No parallel “same meaning” channel should duplicate these transitions.
 
-Potential future case for multi-cluster assignment:
+### 4) UI Layer
 
-- Example: long-running research task split into `Deep Work` (analysis) and `Communication` (stakeholder sync).
-- For v1, this should still be represented as separate sub-tasks rather than one task in two clusters.
+Owns rendering, interaction controls, and local control state:
 
-### 6) Cluster enforcement stance
+- Compose from existing UI-lib/HUD primitives where possible.
+- Keep long/repeated class composition in typed style maps (not business logic branches).
+- Use local imperative control state only for purely presentational toggles (loading/disabled/focus/ARIA sync) where full re-render is unnecessary.
+- Day/Week surfaces are feature composites; lifecycle-heavy parts use controller-style mount/unmount cleanup.
 
-- Product direction is closer to strict assignment semantics:
-  actionable items should be assigned to a matching cluster, not left unstructured.
-- The exact UX strictness (hard blocks vs guided guardrails) remains a design detail.
+UI must dispatch typed module actions rather than mutating persistence directly.
 
-### 7) Prioritization ownership
+### 5) Module Wiring Layer
 
-- Time Clustering does not own internal item ordering/prioritization logic.
-- Prioritization is delegated to the planned `Resource Planner` feature.
-- In Stage 1, assignment of actionable items is not implemented; cluster planning is structural only.
-- Time Clustering becomes a time-bound routing layer (“pipeline”) after assignment is enabled in later stages.
+Owns runtime integration boundaries:
 
-### 8) Adaptivity and rhythm
+- Bootstraps repository + state application services + controllers.
+- Subscribes UI controllers to module state streams.
+- Emits/consumes **global integration events only when crossing module/app-shell boundaries**.
+- Avoids global `window` custom events for internal Time Clustering state flow.
 
-- Cluster structure should be adaptive over time.
-- Day templates may differ by weekday and user rhythm.
-- AI-assisted suggestions should eventually use behavior signals to recommend healthier alternation patterns
-  (focus vs recovery, context switching, cadence).
+This keeps Time Clustering compliant with the hybrid channel model:
 
-### 9) Day view behavior
+- Channel A (module streams): primary for Time Clustering state.
+- Channel C (global integration events): boundary-only.
+- Channel D (local UI control state): local visual controls.
+- Canvas runtime channel stays isolated and is not reused for Time Clustering state.
 
-- Day view is primarily an informational view.
-- Default focus: today.
-- Supports quick navigation to previous/next day.
-- Editing of cluster structure is not required in this compact day-focused mode by default.
+## Reactive Model (Explicit)
 
-### 10) Fullscreen week behavior
+### Source of truth
 
-- Week view is mandatory in fullscreen mode.
-- Primary purpose: forward planning of cluster distribution for upcoming days/week,
-  with optional AI guidance.
+- Authoritative state: `timeClusteringState$` snapshot stream (module-local typed store).
+- Persisted state: repository snapshot (`time_clusters_v1`) as storage mirror, not direct UI source.
 
-### 11) Balance metrics and nudges
+### Event/Action model
 
-- Balance metrics are in scope as supportive feedback.
-- AI-based recommendations are desirable.
-- Nudges should be helpful and subtle, not intrusive.
+- UI interactions and AI apply clicks emit typed module actions.
+- Actions are validated in domain/application services and reduced to next state.
+- Storage writes happen as side effects after successful state transition.
 
-### 12) Carry-over rules by item type (initial)
+### Snapshot/update flow
 
-- `Habit`: generally appears again by its recurrence logic; do not treat as naive carry-over clone.
-- `Task`: usually carried/replanned forward if incomplete, with exceptions for date-specific hard-deadline tasks
-  (e.g., airport transfer) that may require separate handling.
+1. Module boot loads snapshot from repository.
+2. `initializeFromStorage` action hydrates `timeClusteringState$`.
+3. UI subscribes to derived selectors (`dayVm$`, `weekVm$`, `warningsVm$`).
+4. User or AI-apply triggers typed action.
+5. Reducer/service computes next snapshot.
+6. UI updates from stream emission.
+7. Persistence side effect writes new snapshot.
+8. Non-blocking warning/notification channel reports collisions or recoverable issues.
 
-### 13) Mobile posture (current)
+### Side effects boundaries
 
-- Dedicated mobile mode is not critical for first increment.
-- On small screens, only one major workspace surface is expected to be visible at a time
-  (time clustering OR canvas OR AI assistant).
+Pure/stateful split:
 
-### 14) Day-to-day duplication behavior (Stage 1)
+- Pure: domain validation, collision detection, snapshot derivation.
+- Side effects: localStorage I/O, telemetry/logging, notifications, boundary integration events.
 
-- Stage 1 supports one-off day template duplication (copy full day).
-- Collision policy in Stage 1: keep-both and show a warning indicator; no automatic destructive overwrite.
-- Recurrence-based duplication (e.g., weekdays rule) is deferred beyond Stage 1.
+Side effects must not become alternative state-transition channels.
 
-## Relationship To Other Planned Features
+## AI Integration Boundaries (Stage 1)
 
-This feature should integrate with, but remain distinct from:
+AI integration in Stage 1 is action-oriented and constrained.
 
-- `Resource Planner` (planned feature; prioritization, sequencing, resource constraints)
-- planning branches (planned feature)
+### AI output contract
 
-Current assumption:
+AI returns structured suggestion actions (not only prose), for example:
 
-- Resource/branch features choose and sequence work,
-- Time Clustering distributes selected work into realistic day-time boundaries.
-- AI chat integration must include cluster-context access; current canvas-centric context assumptions are not sufficient for Time Clustering suggestion flows.
+- `suggest_create_cluster`
+- `suggest_update_cluster`
+- `suggest_duplicate_day`
+- `suggest_rebalance_day`
 
-## Core UX Concept
+Each suggestion action includes:
 
-The visual model should resemble a calendar timeline,
-but instead of classic event-centric scheduling,
-it emphasizes daily time zones (clusters).
+- intent/type,
+- required payload,
+- human-readable explanation,
+- confidence/priority metadata (optional),
+- deterministic apply preview input.
 
-Users should see what clusters exist for today.
-In Stage 1, focus is cluster structure and visibility; routing actionable items is deferred to later stages.
+### Apply flow
 
-## Required Views (initial)
+- Suggestions are displayed with explicit Apply controls.
+- Apply dispatches the corresponding typed module action.
+- Resulting warnings (e.g., keep-both collisions) are surfaced in UI.
+- No autonomous silent write by AI.
 
-### 1) Day View (compact)
+### Context access limits (Stage 1)
 
-- Compact day-focused presentation used when screen space is constrained or when a narrow side panel is preferred.
-- Focused “today” view with day timeline and active clusters.
-- Informational-first: shows sequence, context, and quick day navigation.
+AI may access:
 
-### 2) Fullscreen View
+- current day/week cluster snapshots,
+- recent cluster history from `time_clusters_v1`,
+- module-level settings relevant to cluster planning.
 
-- Primary planning surface for broader horizon.
-- Must include week mode.
-- Month mode is optional and must be validated by product value before commitment.
+AI must not assume in Stage 1:
 
-## Remaining Open Questions
+- task/habit assignment data inside clusters,
+- Resource Planner sequencing constraints,
+- backend-only availability or cross-user shared state.
 
-1. Should overlap validation be manual (user decides) or rule-assisted (system detects impossible overlaps)?
-2. How should hard-deadline tasks be represented so carry-over does not hide missed commitments?
-3. What is the minimal v1 signal set for AI cluster recommendations (history, energy pattern, category balance)?
-4. Should users be able to pin “non-negotiable” clusters (sleep, medication, commute) before work allocation?
-5. What exact balance metrics should appear first (time share per category, uninterrupted focus depth, recovery ratio)?
+## Relationship to Resource Planner
 
-## Initial Non-Goals
+Time Clustering and Resource Planner are complementary, not overlapping:
 
-- Full autonomous AI scheduler from day one.
-- Complex collaboration workflows in v1.
-- Deep monthly analytics before core day/week flow is validated.
+- Resource Planner (future): prioritization, sequencing, feasibility across actionable items.
+- Time Clustering: temporal structure and protected day/week boundaries.
 
-## Minimum Viable Outcome (draft)
+Stage 1 preserves this boundary by excluding task assignment and planner execution while still shaping contracts to be integration-ready.
 
-### Stage 1 (current target)
+## Views (Stage 1)
+
+### Day View (compact)
+
+- Default focus on current day with quick previous/next day navigation.
+- Informational-first structure visibility.
+- Editing is available for cluster CRUD, with lightweight interaction surface.
+
+### Fullscreen Week View
+
+- Required planning surface for near-term distribution.
+- Supports week-level review and one-off duplication workflows.
+- Month mode is explicitly out of Stage 1 scope unless re-approved.
+
+## Non-Goals (Stage 1)
+
+- Backend persistence/sync.
+- Task/habit assignment into clusters.
+- Planner-grade ordering/optimization.
+- Recurrence-driven duplication automation.
+- Fully autonomous AI scheduler.
+
+## Minimum Viable Outcome (Stage 1)
 
 A user can:
 
-1. create daily time clusters manually,
-2. receive AI suggestions for cluster distribution across day/week and apply them via explicit action controls,
-3. view clusters in day and week contexts,
-4. store and restore cluster plans in browser local storage,
-5. edit/delete clusters and validate visual layout behavior.
+1. create, edit, and delete daily time clusters,
+2. view clusters in day and week contexts,
+3. duplicate one day template to another day (one-off),
+4. handle collisions with keep-both + warning behavior,
+5. receive AI suggestion actions and apply them via explicit controls,
+6. restore state from local storage key `time_clusters_v1`.
 
-### Stage 2+ (future target)
+## Alignment Notes
 
-- Assign `Task` and `Habit` items into clusters.
-- Activate backlog/carry-over behavior for actionable items.
-- Track completion visibility inside each cluster with planner-driven ordering.
+Updated to align with current UI architecture/reactivity standards:
 
+1. Replaced ambiguous “AI text suggestions” framing with explicit structured suggestion actions + apply flow.
+2. Clarified Stage 1 boundary: no backend and no task/habit assignment despite future-domain discussion.
+3. Introduced explicit layered architecture: Domain / Data / State-Application / UI / Module wiring.
+4. Defined a single authoritative module state stream (`timeClusteringState$`) and removed implicit multi-channel ambiguity.
+5. Restricted global events to cross-module boundaries; internal flow uses module-local typed streams.
+6. Separated pure state transitions from side effects (storage, notifications, integration events).
+7. Kept Resource Planner relationship conceptual and non-duplicative for Stage 1.
+
+## Open Decisions (for implementation)
+
+1. **Overlap assistance policy**: only validate + warn in Stage 1, or add rule-assisted “impossible overlap” hints now?
+2. **Suggestion schema versioning**: define `ai_suggestion_action_v1` JSON contract now or in tandem with AI adapter implementation?
+3. **Hydration failure UX**: on invalid local payload, choose between auto-reset, user recovery prompt, or read-only fallback.
+4. **Warning presentation**: inline day/week markers vs notification feed vs both (without duplicating the same signal path).
+5. **Week anchor semantics**: rolling 7-day window vs locale week boundaries as default in fullscreen week mode.

--- a/src/bootstrap/RuntimeHost.ts
+++ b/src/bootstrap/RuntimeHost.ts
@@ -1,6 +1,10 @@
 import { Subscription } from 'rxjs';
 import { GLOBAL_APP_SIDEBAR_WIDTH_PX } from './GlobalAppHeader.ts';
-import { KANBAN_DEV_ENABLED, ROUTINES_ENABLED } from '../config/env/index.ts';
+import {
+  KANBAN_DEV_ENABLED,
+  ROUTINES_ENABLED,
+  TIME_CLUSTERING_DEV_ENABLED,
+} from '../config/env/index.ts';
 import { CanvasModule } from '../features/canvas/CanvasModule.ts';
 import { WallpaperService } from '../features/shell/services/WallpaperService.ts';
 import type { WorkspaceModule } from '../features/shell/WorkspaceModule.ts';
@@ -46,13 +50,21 @@ type KanbanModuleNamespace = {
   KanbanModule: new () => WorkspaceModule;
 };
 
+type TimeClusteringModuleNamespace = {
+  TimeClusteringModule: new () => WorkspaceModule;
+};
+
 const loadKanbanModule = (): Promise<KanbanModuleNamespace> =>
   import('../features/kanban/KanbanModule.ts');
+
+const loadTimeClusteringModule = (): Promise<TimeClusteringModuleNamespace> =>
+  import('../features/time-clustering/TimeClusteringModule.ts');
 
 export class RuntimeHost {
   private shell: WorkspaceShell | null = null;
   private canvasModule: CanvasModule | null = null;
   private kanbanModule: WorkspaceModule | null = null;
+  private timeClusteringModule: WorkspaceModule | null = null;
   private readonly workspaceRoot: HTMLDivElement;
   private readonly wallpaperService: WallpaperService;
   private readonly wallpaperSubscription: Subscription;
@@ -104,9 +116,11 @@ export class RuntimeHost {
 
     this.activeView = loadPersistedWorkspaceView({
       allowKanban: KANBAN_DEV_ENABLED,
+      allowTimeClustering: TIME_CLUSTERING_DEV_ENABLED,
     });
     this.viewSwitcher = new WorkspaceViewSwitcher(this.activeView, {
       showKanban: KANBAN_DEV_ENABLED,
+      showTimeClustering: TIME_CLUSTERING_DEV_ENABLED,
       showRoutines: ROUTINES_ENABLED,
     });
     const chatRuntime = createAiAssistantRuntime({
@@ -249,6 +263,7 @@ export class RuntimeHost {
     this.shell = null;
     this.canvasModule = null;
     this.kanbanModule = null;
+    this.timeClusteringModule = null;
     this.workspaceRoot.remove();
     this.chatPanel.unmount();
     this.chatController.dispose();
@@ -293,6 +308,11 @@ export class RuntimeHost {
         this.kanbanModule = new KanbanModule();
         this.shell.register(this.kanbanModule);
       }
+      if (TIME_CLUSTERING_DEV_ENABLED && !this.timeClusteringModule) {
+        const { TimeClusteringModule } = await loadTimeClusteringModule();
+        this.timeClusteringModule = new TimeClusteringModule();
+        this.shell.register(this.timeClusteringModule);
+      }
       await this.shell.show(this.activeView);
       this.viewSwitcher.setActiveView(this.activeView);
       emitWorkspaceViewChanged(this.activeView);
@@ -305,6 +325,7 @@ export class RuntimeHost {
 
   public async setActiveView(view: WorkspaceView): Promise<void> {
     if (view === 'kanban' && !KANBAN_DEV_ENABLED) return;
+    if (view === 'time-clustering' && !TIME_CLUSTERING_DEV_ENABLED) return;
     this.activeView = view;
     persistWorkspaceView(view);
     if (!this.shell) return;

--- a/src/config/env/index.ts
+++ b/src/config/env/index.ts
@@ -19,6 +19,10 @@ export const CANVAS_PERF_LOG =
 export const KANBAN_DEV_ENABLED =
   IS_DEVELOPMENT_MODE &&
   (parseOptionalBoolean(import.meta.env.VITE_ENABLE_KANBAN_DEV) ?? true);
+export const TIME_CLUSTERING_DEV_ENABLED =
+  IS_DEVELOPMENT_MODE &&
+  (parseOptionalBoolean(import.meta.env.VITE_ENABLE_TIME_CLUSTERING_DEV) ??
+    true);
 export const ROUTINES_ENABLED =
   parseOptionalBoolean(import.meta.env.VITE_ENABLE_ROUTINES) ?? true;
 export const API_URL =

--- a/src/features/shell/WorkspaceControlsBar.ts
+++ b/src/features/shell/WorkspaceControlsBar.ts
@@ -18,6 +18,7 @@ type WorkspaceControlsBarOptions = {
   initialView: WorkspaceView;
   initialChatOpen?: boolean;
   showKanban?: boolean;
+  showTimeClustering?: boolean;
   showRoutines?: boolean;
   showChat?: boolean;
   variant?: WorkspaceControlsBarVariant;
@@ -47,6 +48,7 @@ type VariantMetrics = {
 const VIEW_OPTIONS: ViewOption[] = [
   { view: 'canvas', label: 'Canvas', icon: 'map' },
   { view: 'kanban', label: 'Kanban', icon: 'view-columns' },
+  { view: 'time-clustering', label: 'Time', icon: 'status-pending' },
 ];
 
 const VARIANT_METRICS: Record<WorkspaceControlsBarVariant, VariantMetrics> = {
@@ -130,11 +132,14 @@ export class WorkspaceControlsBar {
     this.chatOpen = options.initialChatOpen ?? false;
 
     const showKanban = options.showKanban ?? true;
+    const showTimeClustering = options.showTimeClustering ?? true;
     const showRoutines = options.showRoutines ?? true;
     const showChat = options.showChat ?? true;
-    const viewOptions = showKanban
-      ? VIEW_OPTIONS
-      : VIEW_OPTIONS.filter((option) => option.view !== 'kanban');
+    const viewOptions = VIEW_OPTIONS.filter((option) => {
+      if (option.view === 'kanban') return showKanban;
+      if (option.view === 'time-clustering') return showTimeClustering;
+      return true;
+    });
     const shouldRenderViewGroup = viewOptions.length > 1;
     this.shouldRender = shouldRenderViewGroup || showRoutines || showChat;
 

--- a/src/features/shell/WorkspaceViewSwitcher.ts
+++ b/src/features/shell/WorkspaceViewSwitcher.ts
@@ -3,6 +3,7 @@ import type { WorkspaceView } from './WorkspaceView.ts';
 
 type WorkspaceViewSwitcherOptions = {
   showKanban?: boolean;
+  showTimeClustering?: boolean;
   showRoutines?: boolean;
   showChat?: boolean;
 };
@@ -19,6 +20,7 @@ export class WorkspaceViewSwitcher {
     this.controls = new WorkspaceControlsBar({
       initialView,
       showKanban: options.showKanban,
+      showTimeClustering: options.showTimeClustering,
       showRoutines: options.showRoutines,
       showChat: options.showChat,
       variant: 'floating',

--- a/src/features/shell/workspaceUiState.ts
+++ b/src/features/shell/workspaceUiState.ts
@@ -6,16 +6,20 @@ const LEGACY_WORKSPACE_CHAT_OPEN_STORAGE_KEY = 'workspace-chat-open';
 
 type LoadPersistedWorkspaceViewOptions = {
   allowKanban?: boolean;
+  allowTimeClustering?: boolean;
 };
 
 export function loadPersistedWorkspaceView(
   options: LoadPersistedWorkspaceViewOptions = {}
 ): WorkspaceView {
   const allowKanban = options.allowKanban ?? true;
+  const allowTimeClustering = options.allowTimeClustering ?? true;
   try {
     const value = localStorage.getItem(WORKSPACE_ACTIVE_VIEW_STORAGE_KEY);
     if (value === 'kanban' && allowKanban) return 'kanban';
-    if (value === 'time-clustering') return 'time-clustering';
+    if (value === 'time-clustering' && allowTimeClustering) {
+      return 'time-clustering';
+    }
   } catch {
     // no-op
   }

--- a/src/features/time-clustering/TimeClusteringApp.ts
+++ b/src/features/time-clustering/TimeClusteringApp.ts
@@ -14,6 +14,7 @@ export class TimeClusteringApp {
 
   public unmount(): void {
     this.view.unmount();
+    this.store.destroy();
   }
 
   public async refreshSuggestions(): Promise<void> {

--- a/src/features/time-clustering/state/TimeClusteringStore.ts
+++ b/src/features/time-clustering/state/TimeClusteringStore.ts
@@ -1,7 +1,15 @@
+import { BehaviorSubject, Subject, Subscription } from 'rxjs';
 import type { TimeClusteringStateSnapshot, TimeClusteringViewMode } from '../domain/types.ts';
 import type { TimeClusteringRepository } from '../data/TimeClusteringRepository.ts';
 
 export type TimeClusteringStoreListener = (snapshot: TimeClusteringStateSnapshot) => void;
+type TimeClusteringStoreAction =
+  | { type: 'setSelectedDate'; dateKey: string }
+  | { type: 'setViewMode'; mode: TimeClusteringViewMode }
+  | {
+      type: 'upsertDayPlan';
+      plan: TimeClusteringStateSnapshot['plansByDate'][string];
+    };
 
 function todayDateKey(): string {
   const now = new Date();
@@ -20,56 +28,81 @@ function createDefaultSnapshot(): TimeClusteringStateSnapshot {
 }
 
 export class TimeClusteringStore {
-  private snapshot: TimeClusteringStateSnapshot;
-  private readonly listeners = new Set<TimeClusteringStoreListener>();
+  private readonly stateSubject: BehaviorSubject<TimeClusteringStateSnapshot>;
+  private readonly actions$ = new Subject<TimeClusteringStoreAction>();
+  private readonly subscriptions = new Subscription();
 
   constructor(private readonly repository: TimeClusteringRepository) {
-    this.snapshot = repository.load() ?? createDefaultSnapshot();
+    this.stateSubject = new BehaviorSubject<TimeClusteringStateSnapshot>(
+      repository.load() ?? createDefaultSnapshot()
+    );
+    this.subscriptions.add(
+      this.actions$.subscribe((action) => {
+        const next = this.reduce(this.stateSubject.value, action);
+        this.stateSubject.next(next);
+        this.repository.save(next);
+      })
+    );
+  }
+
+  public get state$() {
+    return this.stateSubject.asObservable();
   }
 
   public getSnapshot(): TimeClusteringStateSnapshot {
-    return this.snapshot;
+    return this.stateSubject.value;
   }
 
   public subscribe(listener: TimeClusteringStoreListener): () => void {
-    this.listeners.add(listener);
-    listener(this.snapshot);
+    const subscription = this.state$.subscribe(listener);
     return () => {
-      this.listeners.delete(listener);
+      subscription.unsubscribe();
     };
   }
 
   public setSelectedDate(dateKey: string): void {
-    this.snapshot = {
-      ...this.snapshot,
-      selectedDateKey: dateKey,
-    };
-    this.publish();
+    this.actions$.next({ type: 'setSelectedDate', dateKey });
   }
 
   public setViewMode(mode: TimeClusteringViewMode): void {
-    this.snapshot = {
-      ...this.snapshot,
-      viewMode: mode,
-    };
-    this.publish();
+    this.actions$.next({ type: 'setViewMode', mode });
   }
 
   public upsertDayPlan(next: TimeClusteringStateSnapshot['plansByDate'][string]): void {
-    this.snapshot = {
-      ...this.snapshot,
-      plansByDate: {
-        ...this.snapshot.plansByDate,
-        [next.dateKey]: next,
-      },
-    };
-    this.publish();
+    this.actions$.next({ type: 'upsertDayPlan', plan: next });
   }
 
-  private publish(): void {
-    this.repository.save(this.snapshot);
-    for (const listener of this.listeners) {
-      listener(this.snapshot);
+  public destroy(): void {
+    this.subscriptions.unsubscribe();
+    this.actions$.complete();
+    this.stateSubject.complete();
+  }
+
+  private reduce(
+    previous: TimeClusteringStateSnapshot,
+    action: TimeClusteringStoreAction
+  ): TimeClusteringStateSnapshot {
+    switch (action.type) {
+      case 'setSelectedDate':
+        return {
+          ...previous,
+          selectedDateKey: action.dateKey,
+        };
+      case 'setViewMode':
+        return {
+          ...previous,
+          viewMode: action.mode,
+        };
+      case 'upsertDayPlan':
+        return {
+          ...previous,
+          plansByDate: {
+            ...previous.plansByDate,
+            [action.plan.dateKey]: action.plan,
+          },
+        };
+      default:
+        return previous;
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Advance the Time Clustering design from discovery to an implementation-ready Stage 1 frontend that provides local-only day/week cluster planning and AI suggestion actions.
- Align the feature with the app UI/reactivity architecture and establish a replaceable persistence contract for future backend integration.

### Description
- Promote `TIME-CLUSTERING.md` from discovery to a detailed Stage 1 spec and add layered architecture, Stage 1 boundaries, AI suggestion action contract, and view/non-goal definitions.
- Add a dev feature flag `TIME_CLUSTERING_DEV_ENABLED` and wire runtime host to lazy-load and register the `TimeClusteringModule` when enabled, plus surface the view in the controls bar and view switcher.
- Persist time-clustering active view respecting the feature flag via updates to `workspaceUiState.ts` and add the Time view button in `WorkspaceControlsBar` and `WorkspaceViewSwitcher`.
- Implement lifecycle cleanup in `TimeClusteringApp` and convert `TimeClusteringStore` to a reactive RxJS-based store with `state$`, action stream, reducer-style `reduce` logic, repository persistence on transitions, and a `destroy()` method to unsubscribe and complete subjects.

### Testing
- Typechecking and project build were run locally via `pnpm build` and completed successfully. 
- Linting was run via `pnpm lint` and reported no new issues. 
- No automated unit tests were added or modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d23c79e483319b28d54f7fa5afab)