### PR TITLE
docs: add UI style guidelines v2 with concrete visual examples and AGENTS.md updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@
 - Inline utility classes are acceptable for small one-off layout tweaks; avoid large repeated class strings across files.
 - Add new colors/spacing/scales to `tailwind.config.js` when they represent reusable design tokens; do not hardcode repeated design values in feature code.
 - Prefer extending `src/ui-lib/src` primitives and HUD variants over creating feature-local style dialects.
+- On mobile/touch viewports, keep computed `font-size` for text-entry controls (`input`, `textarea`, editable select/search fields) at `16px` or larger to prevent browser auto-zoom on focus.
+- If desktop needs smaller visual input text, apply that only from `md`/desktop breakpoints while preserving `16px` on mobile.
 
 ### Reactive UI Boundaries
 
@@ -130,6 +132,13 @@
 - Owner: `src/ui-lib` + `docs`
 - Read first: `docs/UI-ARCHITECTURE.md`
 - Expected result: keep a stable split between Tailwind tokens, TypeScript component recipes/behavior, and limited template usage for static fragments; avoid large-scale rewrites unless explicitly requested.
+
+### Audit And Enforce UI Style Guidelines
+
+- Use when the request is to define concrete style rules (colors, spacing, radii, borders, shadows, typography, control sizing), audit current non-canvas UI consistency, or prepare migration priorities.
+- Owner: `docs` + `src/ui-lib` + non-canvas feature modules
+- Read first: `docs/UI-STYLE-GUIDELINES.md`
+- Expected result: maintain one practical style policy for new work, identify divergence hotspots, and prioritize incremental convergence to shared ui-lib/hud primitives.
 
 ### Align Reactive UI Channels
 

--- a/docs/UI-STYLE-GUIDELINES.md
+++ b/docs/UI-STYLE-GUIDELINES.md
@@ -1,0 +1,526 @@
+# UI Style Guidelines & Audit (Non-Canvas UI)
+
+## Purpose
+
+This document defines the practical styling standard for non-canvas UI and records the current consistency audit.
+Use it for:
+- implementing new UI features,
+- reviewing pull requests,
+- and prioritizing migration of legacy UI styling.
+
+Scope in this document:
+- `src/ui-lib/src/**`
+- non-canvas feature UI (`src/features/shell`, `src/features/kanban`, `src/features/ai-assistant`, `src/features/time-clustering`)
+
+Excluded:
+- canvas-rendered UI internals and scene-layer visuals.
+
+---
+
+## 1) Non-negotiable style principles
+
+These principles must not be violated in new non-canvas UI work.
+
+1. **Mobile input readability invariant:** on mobile/touch, text-entry controls must keep computed `font-size >= 16px` to prevent browser auto-zoom on focus.
+2. **Primitive-first styling:** do not build new bespoke visual primitives when `ui-lib/hud` already covers the behavior.
+3. **Hierarchy-based corner radius:** larger, higher-level containers use larger radius; compact/low-level controls use smaller radius.
+4. **Border-minimal policy:** borders are opt-in, not default decoration. Use borders only when they improve structure, affordance, or contrast.
+5. **Semantic text system:** use defined text roles (primary/secondary/muted/error/inverse) and avoid ad-hoc color choices in feature code.
+6. **Scale-bound typography and spacing:** font sizes, line heights, and text spacing follow a finite ladder; avoid random one-off values.
+
+---
+
+## 2) Source of truth hierarchy
+
+### 2.1 Mandatory order
+
+1. **Shared HUD/UI-lib primitives and class maps** (`src/ui-lib/src/hud/**`, `src/ui-lib/src/components/modalLayout.ts`).
+2. **Tailwind theme tokens** (`tailwind.config.js`) when introducing reusable semantic values.
+3. **Feature-local composition** only when primitives cannot cover the use-case.
+
+### 2.2 Forbidden by default
+
+- Introducing a feature-local visual dialect for common controls (button/input/select/dropdown/menu/modal) when `ui-lib` already provides equivalents.
+- Repeating large inline style blocks for shared interaction patterns (hover/focus/disabled/error/loading).
+
+---
+
+## 3) Baseline visual language (current standard)
+
+These values reflect the strongest existing conventions in `ui-lib/hud` and modal layout.
+
+### 3.1 Surfaces, borders, and depth
+
+- **Default surface:** white, subtle border, low elevation.
+  - `rounded-2xl`, `border-slate-200/85`, shadow `0 4px 14px rgba(15,23,42,0.08)`.
+- **Elevated surface:** same geometry, stronger elevation.
+  - `rounded-2xl`, `border-slate-200/90`, shadow `0 14px 32px rgba(15,23,42,0.14)`.
+- **Modal container elevation:** stronger overlay depth.
+  - shadow `0 24px 56px rgba(15,23,42,0.18)`.
+
+**Rule:** Use only documented depth levels (`surface`, `surface-elevated`, `overlay`) for reusable UI.
+
+### 3.2 Radius system (hierarchy-based)
+
+- **Level A (page/panel/shell):** `rounded-2xl`.
+- **Level B (card/modal body/grouped surface):** `rounded-xl` to `rounded-2xl` (prefer `rounded-2xl` for major containers).
+- **Level C (controls like input/select/button):** `rounded-lg`.
+- **Level D (dense segmented/compact internals):** `rounded-md`.
+- **Pill entities (chips/tags/status pills):** `rounded-full`.
+
+**Rule:** Larger visual hierarchy = larger corner radius. Smaller control density = smaller radius.
+
+### 3.3 Border policy (minimal-by-default)
+
+- Prefer separation by spacing, background contrast, and elevation first.
+- Add borders only when at least one condition is true:
+  1. control affordance requires edge definition (input/select),
+  2. contrast needs reinforcement on low-elevation surfaces,
+  3. semantic grouping requires explicit division.
+- Avoid nested/double borders (e.g., bordered card + bordered internal wrappers) unless needed for interaction semantics.
+
+### 3.4 Spacing and control sizing
+
+- Primary text input height: `h-11`.
+- Inline compact input height: `h-[34px]`.
+- Common button heights: `h-8`, `h-9`, `h-11`.
+- Menu item row: `px-4 py-3`.
+- **Mobile input font-size guard:** on mobile/touch viewports, all text-entry controls (`input`, `textarea`, editable select/search fields) must use computed `font-size >= 16px` to prevent browser auto-zoom on focus.
+  - If desktop design requires visually smaller typography, scale it down only from `md`/desktop breakpoints and keep mobile at `16px`.
+  - This applies to shared primitives and feature-local compositions.
+
+**Rule:** Use the shared size ladder and avoid one-off heights for reusable controls.
+
+### 3.5 Typography family and size scale
+
+- **Primary UI font family:** `Poppins, sans-serif`.
+- **Fallback chain:** system sans stack (`Inter`, `Segoe UI`, `Roboto`, `Arial`, sans-serif) where platform fallback is needed.
+- **Recommended size ladder by role:**
+  - `12px`: helper/micro labels,
+  - `13px`: compact meta and contextual captions,
+  - `14px`: default body/action text,
+  - `16px`: mobile text-entry controls and prominent body inputs,
+  - `18–30px`: headings by hierarchy.
+- **Line-height guidance:**
+  - dense meta: `1.35–1.45`,
+  - body/action: `1.45–1.6`,
+  - headings: `1.1–1.3`.
+
+### 3.6 Text color semantics
+
+Use semantic tone families:
+- neutral (`slate-*`) for default text/surfaces/borders,
+- accent (`indigo`/`primary`) for interactive emphasis,
+- danger (`rose`/`destructive`) for destructive actions,
+- success/info variants for notifications.
+
+**Rule:** For recurring values, promote to Tailwind semantic token instead of feature-local hex/rgba duplication.
+
+Suggested text color roles:
+- **Primary text:** high-contrast neutral (`slate-900` / near equivalent).
+- **Secondary text:** medium neutral (`slate-600/700`).
+- **Muted/meta text:** low-emphasis neutral (`slate-400/500`).
+- **Interactive accent text:** `indigo`/`primary` semantic colors.
+- **Error text:** `rose`/`destructive` semantic colors.
+- **Inverse text on dark/accent surfaces:** white/high-contrast foreground token.
+
+### 3.6.1 Element color hierarchy (for all UI layers)
+
+Use this hierarchy from strongest visual weight to weakest:
+
+1. **Critical/action states** (error/destructive, success, warning) — only where semantic meaning exists.
+2. **Interactive emphasis** (accent/primary) — CTA, active/selected controls, focused affordances.
+3. **Primary content text** — highest legibility role for core information.
+4. **Secondary content text** — supporting labels and context.
+5. **Muted/support text** — metadata, helper labels, low-priority hints.
+6. **Structural colors** (surface, subtle border/divider) — background organization, not content emphasis.
+
+Rules:
+- Do not use high-emphasis semantic colors for neutral informational text.
+- Do not use danger/success palettes as decoration.
+- One component should normally use one dominant semantic tone + neutral companions.
+
+### 3.7 Text spacing rules
+
+- Keep paragraph spacing semantic, not random:
+  - heading → supporting text: `4–8px`,
+  - form label → control: `4–6px`,
+  - helper/error text under control: `4px`,
+  - section blocks: `12–16px`.
+- Do not rely on empty wrappers for vertical rhythm; use explicit spacing tokens/classes.
+
+### 3.8 Focus, hover, disabled, invalid states
+
+Every interactive control must define:
+- `hover` and `active` states,
+- visible keyboard `focus-visible` ring,
+- disabled visuals and cursor policy,
+- invalid/error state where applicable.
+
+**Rule:** state behavior should be encoded in variant/class maps, not scattered event-driven inline style mutations.
+
+### 3.9 Minimalist beauty principle
+
+The visual default is calm and minimal:
+- Favor whitespace, clear grouping, and typography hierarchy over decorative effects.
+- Keep ornamentation low: avoid unnecessary shadows, gradients, borders, and color noise.
+- Prefer one clear accent per component; avoid multi-accent competition inside one block.
+- Use borders as a functional tool, not a default visual pattern.
+- If removing a visual detail does not reduce usability or meaning, remove it.
+
+---
+
+## 4) Component usage rules
+
+### 4.1 Buttons
+
+Use HUD button primitives:
+- `createTextButton` for textual CTA and action bars,
+- `createIconButton` for icon-only actions,
+- `MenuButton` for trigger + anchored action list.
+
+Avoid creating bespoke `<button>` implementations for common control patterns.
+
+### 4.2 Inputs, textareas, selects
+
+Preferred path:
+- HUD inputs (`createInput`, `createInputBase`) + field/form message primitives.
+
+Legacy components under `src/ui-lib/src/components` are still usable, but new work should converge toward one shared style dialect.
+
+### 4.3 Dropdown and menu patterns
+
+Use:
+- `AnchoredMenu` or `MenuButton` for lifecycle and positioning,
+- `createDropdownItem` and related HUD menu primitives for row rendering and variants.
+
+### 4.4 Modal patterns
+
+Always compose with:
+- `createModalShell`,
+- `createModalActionRow`,
+- `getModalActionButtonClass`.
+
+No bespoke modal focus trap/backdrop logic unless the use-case cannot be expressed with shared modal APIs.
+
+### 4.5 Notifications
+
+Use the shared notification/toast pipeline and keep visual variants semantic (`success`, `error`, `info`).
+
+---
+
+## 5) Tactical application patterns (with examples)
+
+1. **Form field in modal**
+   - Use `rounded-lg` input, subtle border, clear focus ring, and `>=16px` on mobile.
+   - Label uses secondary text role; error uses error text role under control with tight vertical spacing.
+
+2. **Action menu row**
+   - Use shared dropdown item primitive with semantic variants (`default`, `selected`, `danger`).
+   - Avoid adding borders around every row; use hover/selected background and spacing instead.
+
+3. **Card composition**
+   - Top-level card: larger radius (`rounded-xl/2xl`) + minimal border or elevation.
+   - Inner controls: `rounded-lg`; tags/chips `rounded-full`.
+   - Avoid extra nested bordered wrappers unless they communicate state or affordance.
+
+4. **Dense compact controls**
+   - Use smaller radius (`rounded-md`) only for dense sub-controls inside already rounded parents.
+   - Keep clickable area and state visibility accessible.
+
+---
+
+## 6) Current audit: strengths
+
+1. **Strong shared style core in HUD:** centralized class maps for surface/button/menu/input/segmented controls.
+2. **Modal system quality:** reusable layout + responsive presentations + accessibility/focus behavior.
+3. **Composable anchored menus:** robust positioning + reusable item variants.
+4. **Feature reuse exists:** shell routines modal reuses shared modal/menu/button primitives effectively.
+
+---
+
+## 7) Current audit: inconsistencies and risks
+
+### High priority
+
+1. **Multiple parallel styling dialects for primitives**
+   - `src/ui-lib/src/components/*` and `src/ui-lib/src/hud/*` overlap for button/input/select concerns.
+   - Risk: drift in radius, colors, focus states, and future maintenance cost.
+
+2. **Inline-style-heavy feature controllers**
+   - `AiAssistantPanel` and `WorkspaceControlsBar` define many visual decisions as direct DOM style assignments.
+   - Risk: hard to enforce global spacing/color/radius/depth policy and harder to audit.
+
+### Medium priority
+
+3. **Feature-local styling systems not mapped to shared token ladder**
+   - Kanban CSS (`kanbanStyles.ts`) uses its own visual grammar and micro-sizes.
+   - Risk: visual mismatch with shared HUD/modals over time.
+
+4. **Legacy component pockets**
+   - `SearchSelect` uses local dropdown styles (`gray-*`, custom z/depth choices) instead of HUD dropdown/surface primitives.
+
+### Low priority
+
+5. **Compatibility export duplication in HUD public index**
+   - Useful for migration, but increases API surface and can blur “recommended” entry points.
+
+---
+
+## 8) Mandatory PR checklist for new UI
+
+Before merging any non-canvas UI change:
+
+1. Reused existing `ui-lib/hud` primitive where possible.
+2. Avoided bespoke control implementation for common UI controls.
+3. Used shared radius/depth/size ladder.
+4. Implemented hover/focus/disabled (and invalid where needed).
+5. Avoided repeated inline styles for reusable patterns.
+6. Added/used semantic tokens for new recurring design values.
+7. Verified menu/modal behavior uses shared lifecycle primitives.
+8. Confirmed mobile text-entry controls keep computed `font-size >= 16px`.
+9. Confirmed corner radius follows hierarchy (larger container => larger radius; compact control => smaller radius).
+10. Confirmed borders are used only where needed for affordance/contrast/semantic grouping.
+
+If any item is "no", PR must include a brief exception rationale.
+
+---
+
+## 9) Migration plan
+
+### Phase 1 (quick wins)
+
+- Converge new work to HUD-first primitives.
+- Replace feature-local action/menu rows with HUD menu/button variants where behavior is equivalent.
+- Stop adding new bespoke primitive styling in feature modules.
+
+### Phase 2 (targeted refactors)
+
+- Consolidate base `components` and HUD overlap (especially input/select/button conventions).
+- Migrate `SearchSelect` visual layer to shared dropdown/surface style contracts.
+- Normalize shell control bars to shared button primitives and class maps.
+
+### Phase 3 (consistency hardening)
+
+- Map kanban visual system to shared token policy (without forcing full visual redesign).
+- Reduce inline style footprint in AI assistant and shell UI surfaces.
+- Keep compatibility exports but document recommended import paths clearly.
+
+---
+
+## 10) Decision rules for AI-assisted component generation
+
+When generating or updating UI:
+
+1. Check for matching primitive in `src/ui-lib/src/hud` first.
+2. If not found, check `src/ui-lib/src/components` and prefer convergence to HUD style language.
+3. If still missing, create a reusable primitive in `ui-lib` (not feature-local) unless the use-case is truly feature-specific.
+4. Keep repeated styles in typed class/variant maps.
+5. Keep feature modules focused on composition, state, and domain behavior.
+
+---
+
+## 11) Concrete specification extensions (v2 baseline)
+
+### 11.1 Canonical semantic token map
+
+Use canonical token names below for non-canvas UI. These names are the only allowed names for new shared tokens.
+
+| Group | Canonical token | Use | Allowed range / notes |
+|---|---|---|---|
+| Surface | `surface/base` | default panels/cards | neutral light, no tint drift across modules |
+| Surface | `surface/elevated` | dropdown/popover/floating panels | slightly stronger contrast than `surface/base` |
+| Surface | `surface/overlay` | modal/scrim containers | may use alpha backdrop, content remains legible |
+| Text | `text/primary` | core readable content | highest contrast text role |
+| Text | `text/secondary` | support labels/body secondary | medium contrast, still readable |
+| Text | `text/muted` | metadata/hints | lower emphasis, never for critical info |
+| Text | `text/inverse` | text on dark/accent surfaces | contrast-safe inverse foreground |
+| Border | `border/subtle` | optional structural boundary | low-emphasis border only |
+| Border | `border/strong` | required affordance/contrast edge | use rarely and intentionally |
+| State | `state/focus` | focus ring and keyboard visibility | must be visible on all interactive controls |
+| State | `state/error` | invalid/error states | reserved for error semantics only |
+| State | `state/success` | success state feedback | reserved for success semantics only |
+| State | `state/warning` | caution/warning states | reserved for warning semantics only |
+
+Rules:
+- New shared tokens must map to one canonical name from this table.
+- No feature-local synonym names for shared semantics.
+- `error/success/warning` state colors are semantic-only and cannot be used as decoration.
+
+### 11.2 Typography matrix
+
+Use this matrix for all new non-canvas UI text roles.
+
+| Role | Size | Weight | Line-height | Letter-spacing | Typical usage |
+|---|---:|---:|---:|---:|---|
+| `display/lg` | 30px | 600 | 1.1 | -0.01em | large page/title headers |
+| `heading/md` | 24px | 600 | 1.15 | -0.01em | section titles |
+| `heading/sm` | 18px | 600 | 1.25 | -0.005em | card/module headings |
+| `body/md` | 14px | 400-500 | 1.5 | 0 | default body text |
+| `body/sm` | 13px | 400-500 | 1.45 | 0 | compact body/meta |
+| `label/md` | 12px | 500-600 | 1.4 | 0.005em | field labels/control captions |
+| `meta/xs` | 11-12px | 500 | 1.35 | 0.01em | low-priority metadata |
+| `input/mobile` | 16px | 400-500 | 1.45 | 0 | text-entry on mobile/touch |
+
+Localization and long-text edge cases:
+- CJK scripts: allow `+1px` for `body/sm` and below when readability drops.
+- Long German/Finnish-like compounds: prefer wrapping over shrinking text.
+- Do not reduce interactive text below accessible readability thresholds to “fit” layout.
+
+### 11.3 Icon contract
+
+Icon sizing/stroke rules:
+
+| Context | Size | Stroke width | Notes |
+|---|---:|---:|---|
+| Dense inline/icon chip | 12px | 1.8 | use sparingly, ensure optical clarity |
+| Compact control icon | 14px | 1.8 | compact buttons and field adornments |
+| Standard button/menu icon | 16px | 1.8-1.9 | default interactive icon size |
+| Emphasis/large action icon | 18px | 1.9-2.0 | larger CTAs or key affordances |
+| Non-interactive status icon | 12-14px | 1.8 | align baseline with adjacent text |
+
+Alignment rules:
+- Icons align to text optical center, not just geometric center.
+- Keep one icon size per control family in the same row.
+- Do not mix stroke widths in one icon group unless semantically required.
+
+### 11.4 Motion policy
+
+Durations:
+- `micro`: 80-120ms (hover/focus affordance transitions),
+- `standard`: 140-200ms (dropdowns, subtle panel transitions),
+- `complex`: 220-300ms (larger overlays; avoid longer unless justified).
+
+Easing:
+- `standard`: `ease-out` for entry, `ease-in` for exit.
+- Avoid spring/bounce easing for productivity UI primitives by default.
+
+Reduced motion:
+- Respect `prefers-reduced-motion`: reduce or disable non-essential transform/opacity animation.
+
+Forbidden by default:
+- Infinite decorative motion loops in core UI surfaces.
+- Parallax-like movement for standard controls.
+- Long or attention-grabbing animation for routine interactions.
+
+### 11.5 Density modes
+
+Three density modes are allowed:
+
+| Mode | Use case | Control height guidance | Spacing guidance |
+|---|---|---|---|
+| `comfortable` | touch-heavy / mobile-first screens | `h-11` controls baseline | larger section spacing (`12-16px`) |
+| `default` | primary desktop workflows | `h-9` to `h-11` | standard spacing ladder |
+| `compact` | high-density data views | `h-8` to `h-9` | tighter local spacing; preserve readability |
+
+Rules:
+- Density is selected per screen/context, not per random component.
+- Do not mix comfortable and compact controls in one local cluster unless required by semantic priority.
+
+### 11.6 Contrast matrix (role-level minimums)
+
+Use role-level minimum contrast targets:
+
+| Role | Minimum contrast target |
+|---|---:|
+| Primary text | 7:1 preferred, never below 4.5:1 |
+| Secondary text | 4.5:1 minimum |
+| Muted/meta text | 3:1 minimum, never for critical content |
+| Interactive text/icons | 4.5:1 minimum in default state |
+| Focus indicators | clearly perceivable against adjacent surfaces (target 3:1+) |
+| Error/success/warning text | 4.5:1 minimum against background |
+
+---
+
+## 12) Remaining open specification gaps
+
+The following items remain to be finalized:
+
+1. **Dark mode / theme variants:** still not formalized in this document.
+2. **State layering precedence:** conflict rules for simultaneous states (`focused + invalid + disabled-like` transitions).
+3. **Internationalization behavior:** formal truncation/wrapping/RTL priority rules beyond baseline guidance.
+4. **Visual regression criteria:** exact pass/fail thresholds for UI diffs in review.
+
+---
+
+## 13) Visual examples: how elements should look now
+
+Use these as ready-to-apply reference recipes for new non-canvas UI.
+
+### 13.1 Primary action button (default desktop)
+
+- **Shape:** `rounded-lg`
+- **Height:** `h-9` (or `h-11` for touch-heavy contexts)
+- **Typography:** `body/md` (14px, 500)
+- **Color:** accent background + `text/inverse`
+- **States:** visible hover darken, `focus-visible` ring, disabled reduced opacity/interaction lock
+
+Example class recipe:
+
+```ts
+const primaryButtonClass =
+  'inline-flex h-9 items-center justify-center gap-2 rounded-lg px-4 text-[14px] font-medium ' +
+  'bg-indigo-600 text-white hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2 ' +
+  'focus-visible:ring-indigo-400 disabled:cursor-not-allowed disabled:opacity-50';
+```
+
+### 13.2 Text input (mobile-safe)
+
+- **Shape:** `rounded-lg`
+- **Height:** `h-11`
+- **Typography:** `16px` on mobile/touch, can scale to `14px` from `md` and above
+- **Border:** subtle (`border/subtle`) because affordance is required
+- **States:** default, hover, focus ring, invalid, disabled
+
+Example class recipe:
+
+```ts
+const inputClass =
+  'h-11 w-full rounded-lg border border-slate-300 bg-white px-3 text-[16px] text-slate-900 ' +
+  'placeholder:text-slate-400 hover:border-slate-400 focus-visible:outline-none focus-visible:ring-2 ' +
+  'focus-visible:ring-indigo-400 disabled:cursor-not-allowed disabled:bg-slate-100 md:text-[14px]';
+```
+
+### 13.3 Surface card with hierarchy
+
+- **Container:** `rounded-2xl`, low elevation, optional subtle border
+- **Title:** `heading/sm` (18px, 600)
+- **Body:** `body/md` (14px)
+- **Meta:** `body/sm` (13px) in muted tone
+- **Rule:** no extra nested borders unless they communicate real state/affordance
+
+Example class recipe:
+
+```ts
+const surfaceCardClass =
+  'rounded-2xl border border-slate-200/85 bg-white p-4 shadow-[0_4px_14px_rgba(15,23,42,0.08)]';
+```
+
+### 13.4 Dropdown menu row
+
+- **Row spacing:** `px-4 py-3`
+- **Icon:** `16px`, stroke `1.8-1.9`
+- **Colors:** neutral by default, accent for selected, danger only for destructive semantics
+- **Rule:** do not add border around every row; communicate state with tone and background
+
+Example class recipe:
+
+```ts
+const dropdownRowClass =
+  'flex w-full items-center gap-3 rounded-lg px-4 py-3 text-[14px] text-slate-700 ' +
+  'hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300';
+```
+
+### 13.5 Modal shell
+
+- **Container:** `rounded-2xl`, overlay depth shadow
+- **Spacing:** section rhythm 12-16px, label/control gap 4-6px
+- **Buttons:** use shared action-row presets (`h-9` default, `h-11` in touch mode)
+- **Rule:** always use shared modal shell/focus/backdrop lifecycle
+
+Example class recipe:
+
+```ts
+const modalContainerClass =
+  'rounded-2xl bg-white p-5 shadow-[0_24px_56px_rgba(15,23,42,0.18)]';
+```


### PR DESCRIPTION
### Motivation

- Provide a single, actionable non-canvas UI style standard so engineers and AI-assisted flows can generate consistent components.
- Close key specification gaps (semantic token map, typography matrix, icon contract, motion policy, density modes, contrast matrix) needed for reliable component generation.
- Remove ambiguity by adding concrete, copy‑ready visual recipes for common controls so PRs and reviews have a direct reference.

### Description

- Added `docs/UI-STYLE-GUIDELINES.md` containing the v2 baseline spec that includes a canonical semantic token map, typography matrix, icon contract, motion policy, density modes, contrast matrix, tactical usage patterns, migration plan, and remaining open gaps. 
- Appended a new section with concrete visual examples and class recipe snippets for primary action button, mobile-safe text input, surface card, dropdown row, and modal shell to remove ambiguity for implementers. 
- Updated `AGENTS.md` to surface the mobile input font-size invariant and to add the new scenario entry `Audit And Enforce UI Style Guidelines` that points to the guide. 
- Ensured the guide includes non-negotiable principles (primitive-first, border-minimal, radius hierarchy, mobile font guard) and an updated mandatory PR checklist to enforce them.

### Testing

- Ran repository verification checks with `git diff --check` which reported no issues. 
- Searched and validated inserted guide content with `rg -n` for the new headings and example snippets which returned the expected matches. 
- No behavioral code was changed, so no unit tests were added or altered for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d37b795c83319690b1dda7166021)