### PR TITLE
Time Clustering: add docked-left island with fullscreen expansion, state, UI and suggestion actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@
 - On mobile/touch viewports, keep computed `font-size` for text-entry controls (`input`, `textarea`, editable select/search fields) at `16px` or larger to prevent browser auto-zoom on focus.
 - If desktop needs smaller visual input text, apply that only from `md`/desktop breakpoints while preserving `16px` on mobile.
 - For top-level workspace islands (canvas, kanban, time-clustering, AI chat), default to full-size/full-bleed layout without card chrome or decorative outer margins unless separation is functionally required.
+- Time-clustering supports a functional docked-left compact island mode plus explicit fullscreen expansion; treat both as first-class layouts backed by one shared module state source.
 
 ### Reactive UI Boundaries
 

--- a/docs/TIME-CLUSTERING.md
+++ b/docs/TIME-CLUSTERING.md
@@ -215,12 +215,15 @@ Stage 1 preserves this boundary by excluding task assignment and planner executi
 - Default focus on current day with quick previous/next day navigation.
 - Informational-first structure visibility.
 - Editing is available for cluster CRUD, with lightweight interaction surface.
+- Default presentation mode is a docked-left island so users can keep primary workspace context visible.
+- The day island can expand into fullscreen mode when the user needs a larger planning surface.
 
 ### Fullscreen Week View
 
 - Required planning surface for near-term distribution.
 - Supports week-level review and one-off duplication workflows.
 - Month mode is explicitly out of Stage 1 scope unless re-approved.
+- Fullscreen mode is reached through explicit expansion from the docked-left island and uses the same module state source.
 
 ## Non-Goals (Stage 1)
 

--- a/src/bootstrap/RuntimeHost.ts
+++ b/src/bootstrap/RuntimeHost.ts
@@ -45,6 +45,7 @@ import { buildAiAssistantCapabilityContext } from '../features/ai-assistant/serv
 const APP_ISLAND_GAP_PX = 0;
 const APP_ISLAND_MARGIN_PX = 0;
 const APP_ISLAND_RADIUS_PX = 0;
+const TIME_CLUSTERING_ISLAND_WIDTH_PX = 380;
 
 type KanbanModuleNamespace = {
   KanbanModule: new () => WorkspaceModule;
@@ -70,6 +71,7 @@ export class RuntimeHost {
   private readonly wallpaperSubscription: Subscription;
   private currentWallpaperUrl = '';
   private readonly viewSwitcher: WorkspaceViewSwitcher;
+  private readonly timeClusteringIslandRoot: HTMLDivElement;
   private readonly chatPanel: AiAssistantPanel;
   private readonly chatController: AiAssistantSessionController;
   private activeView: WorkspaceView = 'canvas';
@@ -104,6 +106,18 @@ export class RuntimeHost {
     this.workspaceRoot.style.transition =
       'left 180ms ease, top 180ms ease, right 180ms ease, bottom 180ms ease, border-radius 180ms ease, box-shadow 180ms ease';
     document.body.appendChild(this.workspaceRoot);
+    this.timeClusteringIslandRoot = document.createElement('div');
+    this.timeClusteringIslandRoot.id = 'time-clustering-island-root';
+    this.timeClusteringIslandRoot.style.position = 'absolute';
+    this.timeClusteringIslandRoot.style.left = '0';
+    this.timeClusteringIslandRoot.style.top = '0';
+    this.timeClusteringIslandRoot.style.bottom = '0';
+    this.timeClusteringIslandRoot.style.width = `${TIME_CLUSTERING_ISLAND_WIDTH_PX}px`;
+    this.timeClusteringIslandRoot.style.zIndex = '42';
+    this.timeClusteringIslandRoot.style.display = 'none';
+    this.timeClusteringIslandRoot.style.pointerEvents = 'none';
+    this.timeClusteringIslandRoot.style.borderRight = '1px solid rgba(63, 63, 70, 0.9)';
+    this.workspaceRoot.appendChild(this.timeClusteringIslandRoot);
 
     this.wallpaperSubscription = this.wallpaperService.wallpaper$.subscribe(
       (url) => {
@@ -206,7 +220,9 @@ export class RuntimeHost {
   }
 
   private syncWorkspaceWallpaper(): void {
-    const isCanvasVisible = this.hostVisible && this.activeView === 'canvas';
+    const isCanvasVisible =
+      this.hostVisible &&
+      (this.activeView === 'canvas' || this.activeView === 'time-clustering');
     const isKanbanVisible = this.hostVisible && this.activeView === 'kanban';
     if (isCanvasVisible) {
       this.workspaceRoot.style.backgroundImage = '';
@@ -263,7 +279,9 @@ export class RuntimeHost {
     this.shell = null;
     this.canvasModule = null;
     this.kanbanModule = null;
+    this.timeClusteringModule?.unmount();
     this.timeClusteringModule = null;
+    this.timeClusteringIslandRoot.remove();
     this.workspaceRoot.remove();
     this.chatPanel.unmount();
     this.chatController.dispose();
@@ -311,9 +329,11 @@ export class RuntimeHost {
       if (TIME_CLUSTERING_DEV_ENABLED && !this.timeClusteringModule) {
         const { TimeClusteringModule } = await loadTimeClusteringModule();
         this.timeClusteringModule = new TimeClusteringModule();
-        this.shell.register(this.timeClusteringModule);
       }
-      await this.shell.show(this.activeView);
+      await this.shell.show(
+        this.activeView === 'time-clustering' ? 'canvas' : this.activeView
+      );
+      this.syncTimeClusteringIslandVisibility();
       this.viewSwitcher.setActiveView(this.activeView);
       emitWorkspaceViewChanged(this.activeView);
       emitAiAssistantVisibilityChanged(this.chatOpen);
@@ -329,7 +349,8 @@ export class RuntimeHost {
     this.activeView = view;
     persistWorkspaceView(view);
     if (!this.shell) return;
-    await this.shell.show(view);
+    await this.shell.show(view === 'time-clustering' ? 'canvas' : view);
+    this.syncTimeClusteringIslandVisibility();
     this.viewSwitcher.setActiveView(view);
     emitWorkspaceViewChanged(view);
     this.applyVisibility();
@@ -368,12 +389,14 @@ export class RuntimeHost {
       }
       this.viewSwitcher.setVisible(false);
       this.chatPanel.setVisible(false);
+      this.syncTimeClusteringIslandVisibility();
       this.syncWorkspaceWallpaper();
       return;
     }
 
     this.mountRuntimeChrome();
-    const showCanvas = this.activeView === 'canvas';
+    const showCanvas =
+      this.activeView === 'canvas' || this.activeView === 'time-clustering';
     this.workspaceRoot.style.display = 'block';
     this.workspaceRoot.style.pointerEvents = 'auto';
     this.applyWorkspaceLayout(canvasUiRoot, this.chatOpen, chatWidth);
@@ -386,6 +409,7 @@ export class RuntimeHost {
       canvasUiRoot.style.pointerEvents = 'none';
     }
     this.syncCanvasUiRootToWorkspace(canvasUiRoot);
+    this.syncTimeClusteringIslandVisibility();
     this.chatPanel.setIslandMode(this.chatOpen);
     this.viewSwitcher.setVisible(true);
     this.chatPanel.setVisible(this.chatOpen);
@@ -396,7 +420,10 @@ export class RuntimeHost {
   private async executeChatAction(
     request: AiAssistantActionExecutionRequest
   ): Promise<AiAssistantActionExecutionResult> {
-    if (this.activeView !== 'canvas') {
+    if (
+      this.activeView !== 'canvas' &&
+      this.activeView !== 'time-clustering'
+    ) {
       return {
         status: 'failed',
         errorMessage: 'Switch to canvas to create elements.',
@@ -414,7 +441,10 @@ export class RuntimeHost {
   private async executeChatActions(
     requests: AiAssistantActionExecutionRequest[]
   ): Promise<AiAssistantActionExecutionResult[]> {
-    if (this.activeView !== 'canvas') {
+    if (
+      this.activeView !== 'canvas' &&
+      this.activeView !== 'time-clustering'
+    ) {
       return requests.map(() => ({
         status: 'failed' as const,
         errorMessage: 'Switch to canvas to create elements.',
@@ -519,6 +549,26 @@ export class RuntimeHost {
       window.dispatchEvent(new Event('resize'));
       this.layoutSyncTimer = null;
     }, 220);
+  }
+
+  private syncTimeClusteringIslandVisibility(): void {
+    if (!TIME_CLUSTERING_DEV_ENABLED) return;
+    const shouldShowIsland =
+      this.hostVisible && this.activeView === 'time-clustering';
+
+    if (!shouldShowIsland) {
+      this.timeClusteringIslandRoot.style.display = 'none';
+      this.timeClusteringIslandRoot.style.pointerEvents = 'none';
+      return;
+    }
+
+    if (!this.timeClusteringModule) return;
+    if (!this.timeClusteringIslandRoot.hasChildNodes()) {
+      this.timeClusteringModule.mount(this.timeClusteringIslandRoot);
+    }
+
+    this.timeClusteringIslandRoot.style.display = 'block';
+    this.timeClusteringIslandRoot.style.pointerEvents = 'auto';
   }
 
   private setChatOpen(open: boolean): void {

--- a/src/features/time-clustering/TimeClusteringApp.ts
+++ b/src/features/time-clustering/TimeClusteringApp.ts
@@ -1,12 +1,18 @@
 import { LocalStorageTimeClusteringRepository } from './data/LocalStorageTimeClusteringRepository.ts';
 import { TimeClusteringStore } from './state/TimeClusteringStore.ts';
 import { TimeClusteringRootView } from './ui/components/TimeClusteringRootView.ts';
-import { StubTimeClusteringSuggestionService } from './services/TimeClusteringSuggestionService.ts';
+import {
+  StubTimeClusteringSuggestionService,
+  type TimeClusteringSuggestion,
+} from './services/TimeClusteringSuggestionService.ts';
 
 export class TimeClusteringApp {
   private readonly store = new TimeClusteringStore(new LocalStorageTimeClusteringRepository());
-  private readonly view = new TimeClusteringRootView(this.store);
   private readonly suggestionService = new StubTimeClusteringSuggestionService();
+  private readonly view = new TimeClusteringRootView({
+    store: this.store,
+    onRefreshSuggestions: () => this.refreshSuggestions(),
+  });
 
   public mount(parent: HTMLElement): void {
     this.view.mount(parent);
@@ -17,9 +23,9 @@ export class TimeClusteringApp {
     this.store.destroy();
   }
 
-  public async refreshSuggestions(): Promise<void> {
+  public async refreshSuggestions(): Promise<TimeClusteringSuggestion[]> {
     const snapshot = this.store.getSnapshot();
-    await this.suggestionService.buildSuggestions({
+    return this.suggestionService.buildSuggestions({
       dateKey: snapshot.selectedDateKey,
       existingPlans: snapshot.plansByDate,
     });

--- a/src/features/time-clustering/data/LocalStorageTimeClusteringRepository.ts
+++ b/src/features/time-clustering/data/LocalStorageTimeClusteringRepository.ts
@@ -14,9 +14,29 @@ export class LocalStorageTimeClusteringRepository implements TimeClusteringRepos
       const parsed = JSON.parse(raw) as TimeClusteringStateSnapshot;
       if (!parsed || typeof parsed !== 'object') return null;
       if (typeof parsed.selectedDateKey !== 'string') return null;
+      const weekAnchorDateKey =
+        typeof parsed.weekAnchorDateKey === 'string' ? parsed.weekAnchorDateKey : parsed.selectedDateKey;
       if (parsed.viewMode !== 'day-compact' && parsed.viewMode !== 'week-fullscreen') return null;
+      if (parsed.layoutMode !== 'docked-left' && parsed.layoutMode !== 'fullscreen') {
+        return {
+          ...parsed,
+          weekAnchorDateKey,
+          layoutMode: 'docked-left',
+          lastWarnings: Array.isArray(parsed.lastWarnings) ? parsed.lastWarnings : [],
+        };
+      }
       if (!parsed.plansByDate || typeof parsed.plansByDate !== 'object') return null;
-      return parsed;
+      if (!Array.isArray(parsed.lastWarnings)) {
+        return {
+          ...parsed,
+          weekAnchorDateKey,
+          lastWarnings: [],
+        };
+      }
+      return {
+        ...parsed,
+        weekAnchorDateKey,
+      };
     } catch {
       return null;
     }

--- a/src/features/time-clustering/domain/types.ts
+++ b/src/features/time-clustering/domain/types.ts
@@ -1,4 +1,5 @@
 export type TimeClusteringViewMode = 'day-compact' | 'week-fullscreen';
+export type TimeClusteringLayoutMode = 'docked-left' | 'fullscreen';
 
 export interface TimeCluster {
   id: string;
@@ -26,8 +27,24 @@ export interface DuplicationResult {
   warnings: DuplicationWarning[];
 }
 
+export type TimeClusteringSuggestionActionType =
+  | 'suggest_create_cluster'
+  | 'suggest_update_cluster'
+  | 'suggest_duplicate_day'
+  | 'suggest_rebalance_day';
+
+export interface TimeClusteringSuggestionAction {
+  id: string;
+  type: TimeClusteringSuggestionActionType;
+  explanation: string;
+  payload: Record<string, unknown>;
+}
+
 export interface TimeClusteringStateSnapshot {
   selectedDateKey: string;
+  weekAnchorDateKey: string;
   viewMode: TimeClusteringViewMode;
+  layoutMode: TimeClusteringLayoutMode;
   plansByDate: Record<string, DayClusterPlan>;
+  lastWarnings: DuplicationWarning[];
 }

--- a/src/features/time-clustering/index.ts
+++ b/src/features/time-clustering/index.ts
@@ -6,6 +6,7 @@ export {
 } from './data/LocalStorageTimeClusteringRepository.ts';
 export type {
   DayClusterPlan,
+  TimeClusteringLayoutMode,
   TimeCluster,
   TimeClusteringStateSnapshot,
   TimeClusteringViewMode,

--- a/src/features/time-clustering/services/TimeClusteringSuggestionService.ts
+++ b/src/features/time-clustering/services/TimeClusteringSuggestionService.ts
@@ -1,10 +1,10 @@
-import type { DayClusterPlan } from '../domain/types.ts';
+import type { DayClusterPlan, TimeClusteringSuggestionAction } from '../domain/types.ts';
 
 export interface TimeClusteringSuggestion {
   id: string;
   title: string;
   description: string;
-  dayPlans: DayClusterPlan[];
+  action: TimeClusteringSuggestionAction;
 }
 
 export interface TimeClusteringSuggestionService {
@@ -15,11 +15,36 @@ export interface TimeClusteringSuggestionService {
 }
 
 export class StubTimeClusteringSuggestionService implements TimeClusteringSuggestionService {
-  public async buildSuggestions(_params: {
+  public async buildSuggestions(params: {
     dateKey: string;
     existingPlans: Record<string, DayClusterPlan>;
   }): Promise<TimeClusteringSuggestion[]> {
-    // Stage 1 skeleton: replace with AI-backed orchestration.
+    const dayPlan = params.existingPlans[params.dateKey];
+    const hasMorningCluster = dayPlan?.clusters.some((cluster) => cluster.startMinute <= 9 * 60) ?? false;
+
+    if (!hasMorningCluster) {
+      return [
+        {
+          id: `${params.dateKey}_morning_focus`,
+          title: 'Add morning focus block',
+          description: 'Protect a focused morning segment before noon.',
+          action: {
+            id: `${params.dateKey}_morning_focus_action`,
+            type: 'suggest_create_cluster',
+            explanation: 'A dedicated morning block improves predictable progress on priority work.',
+            payload: {
+              dateKey: params.dateKey,
+              title: 'Morning Focus',
+              colorToken: 'indigo',
+              startMinute: 9 * 60,
+              endMinute: 11 * 60,
+              parallelizable: false,
+            },
+          },
+        },
+      ];
+    }
+
     return [];
   }
 }

--- a/src/features/time-clustering/state/TimeClusteringStore.ts
+++ b/src/features/time-clustering/state/TimeClusteringStore.ts
@@ -1,15 +1,36 @@
 import { BehaviorSubject, Subject, Subscription } from 'rxjs';
-import type { TimeClusteringStateSnapshot, TimeClusteringViewMode } from '../domain/types.ts';
+import {
+  duplicateDayPlanKeepBoth,
+  normalizeCluster,
+  validateClusterPlacement,
+} from '../domain/rules.ts';
+import type {
+  DayClusterPlan,
+  TimeCluster,
+  TimeClusteringLayoutMode,
+  TimeClusteringStateSnapshot,
+  TimeClusteringSuggestionAction,
+  TimeClusteringViewMode,
+} from '../domain/types.ts';
 import type { TimeClusteringRepository } from '../data/TimeClusteringRepository.ts';
 
 export type TimeClusteringStoreListener = (snapshot: TimeClusteringStateSnapshot) => void;
 type TimeClusteringStoreAction =
+  | { type: 'initializeFromStorage'; snapshot: TimeClusteringStateSnapshot }
   | { type: 'setSelectedDate'; dateKey: string }
+  | { type: 'setWeekAnchor'; dateKey: string }
   | { type: 'setViewMode'; mode: TimeClusteringViewMode }
+  | { type: 'setLayoutMode'; mode: TimeClusteringLayoutMode }
   | {
       type: 'upsertDayPlan';
       plan: TimeClusteringStateSnapshot['plansByDate'][string];
-    };
+    }
+  | { type: 'createCluster'; dateKey: string; cluster: TimeCluster }
+  | { type: 'updateCluster'; dateKey: string; clusterId: string; patch: Partial<TimeCluster> }
+  | { type: 'deleteCluster'; dateKey: string; clusterId: string }
+  | { type: 'duplicateDayOneOff'; sourceDateKey: string; targetDateKey: string; nowIso: string }
+  | { type: 'applySuggestionAction'; action: TimeClusteringSuggestionAction }
+  | { type: 'applyAiSuggestionAction'; action: TimeClusteringSuggestionAction };
 
 function todayDateKey(): string {
   const now = new Date();
@@ -22,9 +43,26 @@ function todayDateKey(): string {
 function createDefaultSnapshot(): TimeClusteringStateSnapshot {
   return {
     selectedDateKey: todayDateKey(),
+    weekAnchorDateKey: todayDateKey(),
     viewMode: 'day-compact',
+    layoutMode: 'docked-left',
     plansByDate: {},
+    lastWarnings: [],
   };
+}
+
+function createEmptyDayPlan(dateKey: string, nowIso: string): DayClusterPlan {
+  return {
+    dateKey,
+    clusters: [],
+    updatedAtIso: nowIso,
+  };
+}
+
+function uniqueId(): string {
+  return typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `cluster_${Date.now()}_${Math.round(Math.random() * 1_000_000)}`;
 }
 
 export class TimeClusteringStore {
@@ -64,12 +102,57 @@ export class TimeClusteringStore {
     this.actions$.next({ type: 'setSelectedDate', dateKey });
   }
 
+  public setActiveDay(dateKey: string): void {
+    this.actions$.next({ type: 'setSelectedDate', dateKey });
+  }
+
+  public setWeekAnchor(dateKey: string): void {
+    this.actions$.next({ type: 'setWeekAnchor', dateKey });
+  }
+
   public setViewMode(mode: TimeClusteringViewMode): void {
     this.actions$.next({ type: 'setViewMode', mode });
   }
 
+  public setLayoutMode(mode: TimeClusteringLayoutMode): void {
+    this.actions$.next({ type: 'setLayoutMode', mode });
+  }
+
   public upsertDayPlan(next: TimeClusteringStateSnapshot['plansByDate'][string]): void {
     this.actions$.next({ type: 'upsertDayPlan', plan: next });
+  }
+
+  public createCluster(dateKey: string, cluster: TimeCluster): void {
+    this.actions$.next({ type: 'createCluster', dateKey, cluster });
+  }
+
+  public updateCluster(dateKey: string, clusterId: string, patch: Partial<TimeCluster>): void {
+    this.actions$.next({ type: 'updateCluster', dateKey, clusterId, patch });
+  }
+
+  public deleteCluster(dateKey: string, clusterId: string): void {
+    this.actions$.next({ type: 'deleteCluster', dateKey, clusterId });
+  }
+
+  public duplicateDayOneOff(sourceDateKey: string, targetDateKey: string): void {
+    this.actions$.next({
+      type: 'duplicateDayOneOff',
+      sourceDateKey,
+      targetDateKey,
+      nowIso: new Date().toISOString(),
+    });
+  }
+
+  public applySuggestionAction(action: TimeClusteringSuggestionAction): void {
+    this.actions$.next({ type: 'applySuggestionAction', action });
+  }
+
+  public applyAiSuggestionAction(action: TimeClusteringSuggestionAction): void {
+    this.actions$.next({ type: 'applyAiSuggestionAction', action });
+  }
+
+  public initializeFromStorage(snapshot: TimeClusteringStateSnapshot): void {
+    this.actions$.next({ type: 'initializeFromStorage', snapshot });
   }
 
   public destroy(): void {
@@ -83,15 +166,28 @@ export class TimeClusteringStore {
     action: TimeClusteringStoreAction
   ): TimeClusteringStateSnapshot {
     switch (action.type) {
+      case 'initializeFromStorage':
+        return action.snapshot;
       case 'setSelectedDate':
         return {
           ...previous,
           selectedDateKey: action.dateKey,
+          weekAnchorDateKey: action.dateKey,
+        };
+      case 'setWeekAnchor':
+        return {
+          ...previous,
+          weekAnchorDateKey: action.dateKey,
         };
       case 'setViewMode':
         return {
           ...previous,
           viewMode: action.mode,
+        };
+      case 'setLayoutMode':
+        return {
+          ...previous,
+          layoutMode: action.mode,
         };
       case 'upsertDayPlan':
         return {
@@ -100,7 +196,135 @@ export class TimeClusteringStore {
             ...previous.plansByDate,
             [action.plan.dateKey]: action.plan,
           },
+          lastWarnings: [],
         };
+      case 'createCluster': {
+        const nowIso = new Date().toISOString();
+        const currentPlan = previous.plansByDate[action.dateKey] ?? createEmptyDayPlan(action.dateKey, nowIso);
+        const normalizedCluster = normalizeCluster(action.cluster);
+        const warnings = validateClusterPlacement(normalizedCluster, currentPlan.clusters);
+        return {
+          ...previous,
+          plansByDate: {
+            ...previous.plansByDate,
+            [action.dateKey]: {
+              ...currentPlan,
+              updatedAtIso: nowIso,
+              clusters: [...currentPlan.clusters, normalizedCluster],
+            },
+          },
+          lastWarnings: warnings,
+        };
+      }
+      case 'updateCluster': {
+        const nowIso = new Date().toISOString();
+        const currentPlan = previous.plansByDate[action.dateKey];
+        if (!currentPlan) return previous;
+        const nextClusters = currentPlan.clusters.map((cluster) =>
+          cluster.id === action.clusterId ? normalizeCluster({ ...cluster, ...action.patch }) : cluster
+        );
+        const changedCluster = nextClusters.find((cluster) => cluster.id === action.clusterId);
+        const restClusters = nextClusters.filter((cluster) => cluster.id !== action.clusterId);
+        const warnings = changedCluster ? validateClusterPlacement(changedCluster, restClusters) : [];
+        return {
+          ...previous,
+          plansByDate: {
+            ...previous.plansByDate,
+            [action.dateKey]: {
+              ...currentPlan,
+              updatedAtIso: nowIso,
+              clusters: nextClusters,
+            },
+          },
+          lastWarnings: warnings,
+        };
+      }
+      case 'deleteCluster': {
+        const nowIso = new Date().toISOString();
+        const currentPlan = previous.plansByDate[action.dateKey];
+        if (!currentPlan) return previous;
+        return {
+          ...previous,
+          plansByDate: {
+            ...previous.plansByDate,
+            [action.dateKey]: {
+              ...currentPlan,
+              updatedAtIso: nowIso,
+              clusters: currentPlan.clusters.filter((cluster) => cluster.id !== action.clusterId),
+            },
+          },
+          lastWarnings: [],
+        };
+      }
+      case 'duplicateDayOneOff': {
+        const sourcePlan = previous.plansByDate[action.sourceDateKey];
+        if (!sourcePlan) return previous;
+        const result = duplicateDayPlanKeepBoth({
+          source: sourcePlan,
+          targetDateKey: action.targetDateKey,
+          targetExisting: previous.plansByDate[action.targetDateKey] ?? null,
+          nowIso: action.nowIso,
+        });
+        return {
+          ...previous,
+          plansByDate: {
+            ...previous.plansByDate,
+            [action.targetDateKey]: result.plan,
+          },
+          lastWarnings: result.warnings,
+        };
+      }
+      case 'applyAiSuggestionAction':
+      case 'applySuggestionAction': {
+        const payload = action.action.payload;
+        switch (action.action.type) {
+          case 'suggest_create_cluster': {
+            const dateKey =
+              typeof payload.dateKey === 'string' && payload.dateKey.length > 0
+                ? payload.dateKey
+                : previous.selectedDateKey;
+            const title = typeof payload.title === 'string' ? payload.title : 'Suggested cluster';
+            const cluster: TimeCluster = normalizeCluster({
+              id: uniqueId(),
+              title,
+              colorToken: typeof payload.colorToken === 'string' ? payload.colorToken : 'violet',
+              startMinute: Number(payload.startMinute ?? 540),
+              endMinute: Number(payload.endMinute ?? 600),
+              parallelizable: Boolean(payload.parallelizable),
+            });
+            return this.reduce(previous, { type: 'createCluster', dateKey, cluster });
+          }
+          case 'suggest_update_cluster': {
+            const dateKey =
+              typeof payload.dateKey === 'string' && payload.dateKey.length > 0
+                ? payload.dateKey
+                : previous.selectedDateKey;
+            const clusterId = typeof payload.clusterId === 'string' ? payload.clusterId : '';
+            if (!clusterId) return previous;
+            return this.reduce(previous, {
+              type: 'updateCluster',
+              dateKey,
+              clusterId,
+              patch: payload as Partial<TimeCluster>,
+            });
+          }
+          case 'suggest_duplicate_day': {
+            const sourceDateKey =
+              typeof payload.sourceDateKey === 'string' ? payload.sourceDateKey : previous.selectedDateKey;
+            const targetDateKey =
+              typeof payload.targetDateKey === 'string' ? payload.targetDateKey : previous.selectedDateKey;
+            return this.reduce(previous, {
+              type: 'duplicateDayOneOff',
+              sourceDateKey,
+              targetDateKey,
+              nowIso: new Date().toISOString(),
+            });
+          }
+          case 'suggest_rebalance_day':
+          default:
+            return previous;
+        }
+      }
       default:
         return previous;
     }

--- a/src/features/time-clustering/ui/components/TimeClusteringRootView.ts
+++ b/src/features/time-clustering/ui/components/TimeClusteringRootView.ts
@@ -1,37 +1,420 @@
+import type { TimeCluster, TimeClusteringStateSnapshot } from '../../domain/types.ts';
+import type { TimeClusteringSuggestion } from '../../services/TimeClusteringSuggestionService.ts';
 import type { TimeClusteringStore } from '../../state/TimeClusteringStore.ts';
 
+interface TimeClusteringRootViewOptions {
+  store: TimeClusteringStore;
+  onRefreshSuggestions: () => Promise<TimeClusteringSuggestion[]>;
+}
+
+function uniqueId(): string {
+  return typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `cluster_${Date.now()}_${Math.round(Math.random() * 1_000_000)}`;
+}
+
+function formatMinute(minute: number): string {
+  const clamped = Math.max(0, Math.min(24 * 60, minute));
+  const hours = Math.floor(clamped / 60)
+    .toString()
+    .padStart(2, '0');
+  const mins = Math.floor(clamped % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${hours}:${mins}`;
+}
+
+function parseMinute(value: string): number {
+  const [hoursRaw, minutesRaw] = value.split(':');
+  const hours = Number(hoursRaw ?? 0);
+  const minutes = Number(minutesRaw ?? 0);
+  return Math.max(0, Math.min(24 * 60, hours * 60 + minutes));
+}
+
+function dayOffsetDateKey(baseDateKey: string, offset: number): string {
+  const date = new Date(`${baseDateKey}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return baseDateKey;
+  date.setDate(date.getDate() + offset);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 export class TimeClusteringRootView {
+  private readonly store: TimeClusteringStore;
+  private readonly onRefreshSuggestions: () => Promise<TimeClusteringSuggestion[]>;
   private readonly root: HTMLDivElement;
-  private readonly title: HTMLHeadingElement;
-  private readonly subtitle: HTMLParagraphElement;
+  private readonly panel: HTMLDivElement;
+  private readonly workspaceMain: HTMLDivElement;
+  private readonly dateInput: HTMLInputElement;
+  private readonly modeLabel: HTMLSpanElement;
+  private readonly layoutLabel: HTMLSpanElement;
+  private readonly statsLabel: HTMLParagraphElement;
+  private readonly dayList: HTMLDivElement;
+  private readonly weekList: HTMLDivElement;
+  private readonly warningsList: HTMLUListElement;
+  private readonly duplicateTargetInput: HTMLInputElement;
+  private readonly newTitleInput: HTMLInputElement;
+  private readonly newColorInput: HTMLInputElement;
+  private readonly newStartInput: HTMLInputElement;
+  private readonly newEndInput: HTMLInputElement;
+  private readonly newParallelizableInput: HTMLInputElement;
+  private readonly suggestionsList: HTMLDivElement;
+  private readonly expandButton: HTMLButtonElement;
+  private readonly dayModeButton: HTMLButtonElement;
+  private readonly weekModeButton: HTMLButtonElement;
   private disposeStoreSubscription: (() => void) | null = null;
 
-  constructor(private readonly store: TimeClusteringStore) {
+  constructor(options: TimeClusteringRootViewOptions) {
+    this.store = options.store;
+    this.onRefreshSuggestions = options.onRefreshSuggestions;
+
     this.root = document.createElement('div');
-    this.root.className = 'h-full w-full p-4 text-zinc-100';
+    this.root.className = 'h-full w-full bg-zinc-950 text-zinc-100';
 
-    this.title = document.createElement('h2');
-    this.title.className = 'text-lg font-semibold';
-    this.title.textContent = 'Time Clustering';
+    this.panel = document.createElement('div');
+    this.panel.className = 'h-full overflow-auto border-r border-zinc-800 bg-zinc-950 p-4';
 
-    this.subtitle = document.createElement('p');
-    this.subtitle.className = 'mt-2 text-sm text-zinc-400';
+    this.workspaceMain = document.createElement('div');
+    this.workspaceMain.className = 'flex h-full flex-1 items-center justify-center p-8 text-zinc-400';
+    this.workspaceMain.textContent =
+      'Main workspace area. Open Time Clustering in fullscreen for full week planning.';
 
-    this.root.append(this.title, this.subtitle);
+    const layout = document.createElement('div');
+    layout.className = 'flex h-full w-full';
+
+    const header = document.createElement('div');
+    header.className = 'mb-4 flex flex-wrap items-center gap-2';
+
+    const title = document.createElement('h2');
+    title.className = 'mr-3 text-lg font-semibold';
+    title.textContent = 'Time Clustering';
+
+    this.layoutLabel = document.createElement('span');
+    this.layoutLabel.className = 'rounded bg-zinc-800 px-2 py-1 text-xs text-zinc-300';
+
+    this.modeLabel = document.createElement('span');
+    this.modeLabel.className = 'rounded bg-zinc-800 px-2 py-1 text-xs text-zinc-300';
+
+    this.dayModeButton = document.createElement('button');
+    this.dayModeButton.className = 'rounded bg-zinc-800 px-3 py-1 text-sm';
+    this.dayModeButton.textContent = 'Day';
+    this.dayModeButton.onclick = () => this.store.setViewMode('day-compact');
+
+    this.weekModeButton = document.createElement('button');
+    this.weekModeButton.className = 'rounded bg-zinc-800 px-3 py-1 text-sm';
+    this.weekModeButton.textContent = 'Week';
+    this.weekModeButton.onclick = () => this.store.setViewMode('week-fullscreen');
+
+    this.expandButton = document.createElement('button');
+    this.expandButton.className = 'rounded bg-indigo-600 px-3 py-1 text-sm font-medium';
+    this.expandButton.onclick = () => {
+      const snapshot = this.store.getSnapshot();
+      const nextLayout = snapshot.layoutMode === 'docked-left' ? 'fullscreen' : 'docked-left';
+      this.store.setLayoutMode(nextLayout);
+      if (nextLayout === 'fullscreen') {
+        this.store.setViewMode('week-fullscreen');
+      } else {
+        this.store.setViewMode('day-compact');
+      }
+    };
+
+    const prevDayButton = document.createElement('button');
+    prevDayButton.className = 'rounded bg-zinc-800 px-3 py-1 text-sm';
+    prevDayButton.textContent = '←';
+    prevDayButton.onclick = () => {
+      this.store.setSelectedDate(dayOffsetDateKey(this.store.getSnapshot().selectedDateKey, -1));
+    };
+
+    this.dateInput = document.createElement('input');
+    this.dateInput.type = 'date';
+    this.dateInput.className = 'rounded bg-zinc-900 px-3 py-1 text-sm';
+    this.dateInput.onchange = () => {
+      if (this.dateInput.value) {
+        this.store.setSelectedDate(this.dateInput.value);
+      }
+    };
+
+    const nextDayButton = document.createElement('button');
+    nextDayButton.className = 'rounded bg-zinc-800 px-3 py-1 text-sm';
+    nextDayButton.textContent = '→';
+    nextDayButton.onclick = () => {
+      this.store.setSelectedDate(dayOffsetDateKey(this.store.getSnapshot().selectedDateKey, 1));
+    };
+
+    header.append(
+      title,
+      this.layoutLabel,
+      this.modeLabel,
+      this.dayModeButton,
+      this.weekModeButton,
+      this.expandButton,
+      prevDayButton,
+      this.dateInput,
+      nextDayButton
+    );
+
+    this.statsLabel = document.createElement('p');
+    this.statsLabel.className = 'mb-3 text-sm text-zinc-400';
+
+    const createForm = document.createElement('div');
+    createForm.className = 'mb-4 flex flex-wrap items-center gap-2 rounded bg-zinc-900/70 p-3';
+
+    this.newTitleInput = document.createElement('input');
+    this.newTitleInput.placeholder = 'Cluster title';
+    this.newTitleInput.className = 'min-w-36 rounded bg-zinc-800 px-3 py-2 text-base';
+
+    this.newColorInput = document.createElement('input');
+    this.newColorInput.placeholder = 'Color token';
+    this.newColorInput.value = 'violet';
+    this.newColorInput.className = 'w-28 rounded bg-zinc-800 px-3 py-2 text-base';
+
+    this.newStartInput = document.createElement('input');
+    this.newStartInput.type = 'time';
+    this.newStartInput.value = '09:00';
+    this.newStartInput.className = 'rounded bg-zinc-800 px-3 py-2 text-base';
+
+    this.newEndInput = document.createElement('input');
+    this.newEndInput.type = 'time';
+    this.newEndInput.value = '10:00';
+    this.newEndInput.className = 'rounded bg-zinc-800 px-3 py-2 text-base';
+
+    const parallelLabel = document.createElement('label');
+    parallelLabel.className = 'flex items-center gap-2 text-sm text-zinc-300';
+    this.newParallelizableInput = document.createElement('input');
+    this.newParallelizableInput.type = 'checkbox';
+    parallelLabel.append(this.newParallelizableInput, document.createTextNode('Parallelizable'));
+
+    const addClusterButton = document.createElement('button');
+    addClusterButton.className = 'rounded bg-indigo-600 px-3 py-2 text-sm font-medium';
+    addClusterButton.textContent = 'Add cluster';
+    addClusterButton.onclick = () => {
+      const selectedDateKey = this.store.getSnapshot().selectedDateKey;
+      this.store.createCluster(selectedDateKey, {
+        id: uniqueId(),
+        title: this.newTitleInput.value.trim() || 'Untitled cluster',
+        colorToken: this.newColorInput.value.trim() || 'violet',
+        startMinute: parseMinute(this.newStartInput.value),
+        endMinute: parseMinute(this.newEndInput.value),
+        parallelizable: this.newParallelizableInput.checked,
+      });
+    };
+
+    createForm.append(
+      this.newTitleInput,
+      this.newColorInput,
+      this.newStartInput,
+      this.newEndInput,
+      parallelLabel,
+      addClusterButton
+    );
+
+    const duplicateBar = document.createElement('div');
+    duplicateBar.className = 'mb-4 flex flex-wrap items-center gap-2';
+
+    this.duplicateTargetInput = document.createElement('input');
+    this.duplicateTargetInput.type = 'date';
+    this.duplicateTargetInput.className = 'rounded bg-zinc-900 px-3 py-2 text-base';
+
+    const duplicateButton = document.createElement('button');
+    duplicateButton.className = 'rounded bg-zinc-800 px-3 py-2 text-sm';
+    duplicateButton.textContent = 'Duplicate selected day → target';
+    duplicateButton.onclick = () => {
+      const sourceDateKey = this.store.getSnapshot().selectedDateKey;
+      const targetDateKey = this.duplicateTargetInput.value || sourceDateKey;
+      this.store.duplicateDayOneOff(sourceDateKey, targetDateKey);
+      this.store.setSelectedDate(targetDateKey);
+    };
+
+    const refreshSuggestionsButton = document.createElement('button');
+    refreshSuggestionsButton.className = 'rounded bg-zinc-800 px-3 py-2 text-sm';
+    refreshSuggestionsButton.textContent = 'Refresh suggestions';
+    refreshSuggestionsButton.onclick = async () => {
+      await this.renderSuggestions();
+    };
+
+    duplicateBar.append(this.duplicateTargetInput, duplicateButton, refreshSuggestionsButton);
+
+    this.dayList = document.createElement('div');
+    this.dayList.className = 'mb-4 space-y-2';
+
+    this.weekList = document.createElement('div');
+    this.weekList.className = 'mb-4 hidden space-y-2';
+
+    const warningsTitle = document.createElement('h3');
+    warningsTitle.className = 'mt-4 text-sm font-semibold text-amber-300';
+    warningsTitle.textContent = 'Warnings';
+    this.warningsList = document.createElement('ul');
+    this.warningsList.className = 'mb-4 list-disc pl-5 text-sm text-amber-200';
+
+    const suggestionsTitle = document.createElement('h3');
+    suggestionsTitle.className = 'text-sm font-semibold text-zinc-200';
+    suggestionsTitle.textContent = 'AI suggestions';
+    this.suggestionsList = document.createElement('div');
+    this.suggestionsList.className = 'space-y-2';
+
+    this.panel.append(
+      header,
+      this.statsLabel,
+      createForm,
+      duplicateBar,
+      this.dayList,
+      this.weekList,
+      warningsTitle,
+      this.warningsList,
+      suggestionsTitle,
+      this.suggestionsList
+    );
+
+    layout.append(this.panel, this.workspaceMain);
+    this.root.append(layout);
   }
 
   public mount(parent: HTMLElement): void {
     parent.appendChild(this.root);
     this.disposeStoreSubscription = this.store.subscribe((snapshot) => {
-      this.subtitle.textContent = `Mode: ${snapshot.viewMode} • Date: ${snapshot.selectedDateKey} • Days planned: ${Object.keys(
-        snapshot.plansByDate
-      ).length}`;
+      this.renderSnapshot(snapshot);
     });
+    this.renderSnapshot(this.store.getSnapshot());
+    void this.renderSuggestions();
   }
 
   public unmount(): void {
     this.disposeStoreSubscription?.();
     this.disposeStoreSubscription = null;
     this.root.remove();
+  }
+
+  private renderSnapshot(snapshot: TimeClusteringStateSnapshot): void {
+    this.modeLabel.textContent = snapshot.viewMode;
+    this.layoutLabel.textContent = snapshot.layoutMode;
+    this.expandButton.textContent =
+      snapshot.layoutMode === 'docked-left' ? 'Expand to fullscreen' : 'Collapse to left island';
+
+    this.dateInput.value = snapshot.selectedDateKey;
+    this.duplicateTargetInput.value ||= snapshot.selectedDateKey;
+
+    const selectedPlan = snapshot.plansByDate[snapshot.selectedDateKey];
+    const selectedClusters = selectedPlan?.clusters ?? [];
+
+    this.statsLabel.textContent = `Date: ${snapshot.selectedDateKey} • Planned days: ${Object.keys(snapshot.plansByDate).length} • Clusters today: ${selectedClusters.length}`;
+
+    this.dayList.innerHTML = '';
+    selectedClusters
+      .slice()
+      .sort((a, b) => a.startMinute - b.startMinute)
+      .forEach((cluster) => {
+        this.dayList.append(this.renderClusterRow(snapshot.selectedDateKey, cluster));
+      });
+
+    this.weekList.innerHTML = '';
+    const weekDateKeys = Array.from({ length: 7 }).map((_, index) =>
+      dayOffsetDateKey(snapshot.weekAnchorDateKey, index)
+    );
+    weekDateKeys.forEach((dateKey) => {
+      const item = document.createElement('div');
+      item.className = 'rounded bg-zinc-900/70 px-3 py-2 text-sm';
+      const count = snapshot.plansByDate[dateKey]?.clusters.length ?? 0;
+      item.textContent = `${dateKey}: ${count} cluster(s)`;
+      this.weekList.appendChild(item);
+    });
+
+    const isDayMode = snapshot.viewMode === 'day-compact';
+    this.dayList.classList.toggle('hidden', !isDayMode);
+    this.weekList.classList.toggle('hidden', isDayMode);
+
+    const isDocked = snapshot.layoutMode === 'docked-left';
+    this.panel.style.width = isDocked ? '380px' : '100%';
+    this.dayModeButton.disabled = false;
+    this.weekModeButton.disabled = false;
+    this.workspaceMain.style.display = isDocked ? 'flex' : 'none';
+
+    this.warningsList.innerHTML = '';
+    if (snapshot.lastWarnings.length === 0) {
+      const li = document.createElement('li');
+      li.textContent = 'No warnings';
+      this.warningsList.appendChild(li);
+      return;
+    }
+
+    snapshot.lastWarnings.forEach((warning) => {
+      const li = document.createElement('li');
+      li.textContent = `Collision: ${warning.sourceClusterId} ↔ ${warning.targetClusterId}`;
+      this.warningsList.appendChild(li);
+    });
+  }
+
+  private renderClusterRow(dateKey: string, cluster: TimeCluster): HTMLDivElement {
+    const row = document.createElement('div');
+    row.className = 'flex flex-wrap items-center gap-2 rounded bg-zinc-900/70 px-3 py-2';
+
+    const name = document.createElement('span');
+    name.className = 'min-w-40 text-sm font-medium';
+    name.textContent = `${cluster.title} (${cluster.colorToken})`;
+
+    const time = document.createElement('span');
+    time.className = 'text-sm text-zinc-300';
+    time.textContent = `${formatMinute(cluster.startMinute)}–${formatMinute(cluster.endMinute)}`;
+
+    const parallel = document.createElement('span');
+    parallel.className = 'text-xs text-zinc-400';
+    parallel.textContent = cluster.parallelizable ? 'parallelizable' : 'exclusive';
+
+    const shiftButton = document.createElement('button');
+    shiftButton.className = 'rounded bg-zinc-800 px-2 py-1 text-xs';
+    shiftButton.textContent = '+30m';
+    shiftButton.onclick = () => {
+      this.store.updateCluster(dateKey, cluster.id, {
+        startMinute: cluster.startMinute + 30,
+        endMinute: cluster.endMinute + 30,
+      });
+    };
+
+    const deleteButton = document.createElement('button');
+    deleteButton.className = 'rounded bg-rose-700 px-2 py-1 text-xs';
+    deleteButton.textContent = 'Delete';
+    deleteButton.onclick = () => {
+      this.store.deleteCluster(dateKey, cluster.id);
+    };
+
+    row.append(name, time, parallel, shiftButton, deleteButton);
+    return row;
+  }
+
+  private async renderSuggestions(): Promise<void> {
+    const suggestions = await this.onRefreshSuggestions();
+    this.suggestionsList.innerHTML = '';
+
+    if (suggestions.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'text-sm text-zinc-400';
+      empty.textContent = 'No suggestion actions right now.';
+      this.suggestionsList.appendChild(empty);
+      return;
+    }
+
+    suggestions.forEach((suggestion) => {
+      const card = document.createElement('div');
+      card.className = 'rounded bg-zinc-900/70 p-3';
+
+      const title = document.createElement('p');
+      title.className = 'text-sm font-semibold';
+      title.textContent = suggestion.title;
+
+      const description = document.createElement('p');
+      description.className = 'mt-1 text-sm text-zinc-300';
+      description.textContent = suggestion.description;
+
+      const applyButton = document.createElement('button');
+      applyButton.className = 'mt-2 rounded bg-emerald-700 px-2 py-1 text-xs';
+      applyButton.textContent = 'Apply';
+      applyButton.onclick = () => {
+        this.store.applySuggestionAction(suggestion.action);
+      };
+
+      card.append(title, description, applyButton);
+      this.suggestionsList.append(card);
+    });
   }
 }


### PR DESCRIPTION
### Motivation

- Introduce a first-class docked-left compact island mode for the Time Clustering feature while preserving an explicit fullscreen expansion path backed by the same module state. 
- Provide actionable AI-backed suggestion actions and a clear apply flow rather than free-form text suggestions for Stage 1. 
- Harden persisted snapshot compatibility and extend the domain model to support layout and suggestion action metadata. 

### Description

- Added a left-docked island host and lifecycle integration in `src/bootstrap/RuntimeHost.ts`, including island root creation, visibility sync, wallpaper/layout adjustments, and mapping `time-clustering` to the canvas presentation when appropriate.
- Extended domain and data types in `src/features/time-clustering/domain/types.ts` to include `TimeClusteringLayoutMode`, `weekAnchorDateKey`, `lastWarnings`, and typed suggestion action shapes, and exported the new type from the module index.
- Made storage resilient in `LocalStorageTimeClusteringRepository.ts` by migrating older snapshots and ensuring default values for new fields like `weekAnchorDateKey`, `layoutMode`, and `lastWarnings`.
- Implemented a richer store in `TimeClusteringStore.ts` with many new actions (`createCluster`, `updateCluster`, `deleteCluster`, `duplicateDayOneOff`, `applySuggestionAction`, etc.), reducers that validate/normalize clusters and produce `lastWarnings`, and helper functions for IDs and empty plans.
- Reworked the suggestion API and provided a stub actionable suggestion in `TimeClusteringSuggestionService.ts` that returns typed `TimeClusteringSuggestion` items with `action` payloads.
- Rewrote the feature UI as a contained `TimeClusteringRootView` (and adjusted `TimeClusteringApp`) to support docked vs fullscreen layout toggle, day/week modes, date navigation, cluster CRUD controls, duplication action, showing warnings, and rendering/applying suggestion actions.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4253aecf483318d3a8d81cdf46f29)