### PR TITLE
Add theme support to AppRuntime snapshot and subscriptions

### DIFF
--- a/src/app-runtime/AppRuntime.test.ts
+++ b/src/app-runtime/AppRuntime.test.ts
@@ -14,8 +14,38 @@ describe('AppRuntime', () => {
     const runtime = createAppRuntime({ initialLocale: 'uk' });
 
     expect(runtime.getSnapshot().locale).toBe('uk');
+    expect(runtime.getSnapshot().theme).toBe('light');
     expect(runtime.getSnapshot().energy.level).toBeNull();
+    expect(runtime.getTheme()).toBe('light');
     expect(runtime.i18n.getLocale()).toBe('uk');
+  });
+
+  it('emits a snapshot when the theme changes', () => {
+    const runtime = createAppRuntime({ initialLocale: 'en' });
+    const themes: string[] = [];
+
+    runtime.subscribe((snapshot) => {
+      themes.push(snapshot.theme);
+    });
+
+    runtime.setTheme('dark');
+
+    expect(themes).toEqual(['dark']);
+    expect(runtime.getSnapshot().theme).toBe('dark');
+  });
+
+  it('does not emit duplicate snapshots when setting the same theme', () => {
+    const runtime = createAppRuntime({ initialLocale: 'en' });
+    const themes: string[] = [];
+
+    runtime.subscribe((snapshot) => {
+      themes.push(snapshot.theme);
+    });
+
+    runtime.setTheme('dark');
+    runtime.setTheme('dark');
+
+    expect(themes).toEqual(['dark']);
   });
 
   it('notifies subscribers when locale changes through runtime', () => {

--- a/src/app-runtime/AppRuntime.ts
+++ b/src/app-runtime/AppRuntime.ts
@@ -16,14 +16,17 @@ export type AppEnergyState = {
 
 export type AppRuntimeSnapshot = {
   locale: AppLocale;
+  theme: AppTheme;
   energy: AppEnergyState;
 };
 
 export type AppRuntimeListener = (snapshot: AppRuntimeSnapshot) => void;
+export type AppTheme = 'light' | 'dark';
 
 type AppRuntimeOptions = {
   i18n?: I18nService;
   initialLocale?: AppLocale | string | string[] | null;
+  initialTheme?: AppTheme;
   energyService?: AppEnergyService | null;
 };
 type AppRuntimeSubscribeOptions = {
@@ -35,6 +38,7 @@ export class AppRuntime {
 
   private readonly listeners = new Set<AppRuntimeListener>();
   private readonly energyService: AppEnergyService | null;
+  private theme: AppTheme;
   private energyState: AppEnergyState = {
     level: null,
     recordId: null,
@@ -52,6 +56,7 @@ export class AppRuntime {
       options.energyService === undefined
         ? new ShellEnergyService()
         : options.energyService;
+    this.theme = options.initialTheme ?? 'light';
     this.i18n.subscribe(() => {
       this.emitSnapshot();
     });
@@ -60,8 +65,13 @@ export class AppRuntime {
   public getSnapshot(): AppRuntimeSnapshot {
     return {
       locale: this.i18n.getLocale(),
+      theme: this.theme,
       energy: this.getEnergyState(),
     };
+  }
+
+  public getTheme(): AppTheme {
+    return this.theme;
   }
 
   public getEnergyState(): AppEnergyState {
@@ -85,6 +95,15 @@ export class AppRuntime {
     locale: AppLocale | string | string[] | null | undefined
   ): AppLocale {
     return this.i18n.setLocale(locale);
+  }
+
+  public setTheme(theme: AppTheme): AppTheme {
+    if (this.theme === theme) {
+      return this.theme;
+    }
+    this.theme = theme;
+    this.emitSnapshot();
+    return this.theme;
   }
 
   public async ensureEnergyLoaded(): Promise<void> {

--- a/src/app-runtime/index.ts
+++ b/src/app-runtime/index.ts
@@ -2,6 +2,7 @@ export {
   AppRuntime,
   createAppRuntime,
   type AppEnergyState,
+  type AppTheme,
   type AppRuntimeListener,
   type AppRuntimeSnapshot,
 } from './AppRuntime.ts';


### PR DESCRIPTION
### Motivation
- Surface app-wide `theme` as part of the app-level runtime snapshot so subscribers can react to theme changes and the runtime remains the single source of truth for UI-level preferences.
- Avoid noisy duplicate subscriber emissions by guarding `setTheme` so re-setting the same theme does not re-emit snapshots.

### Description
- Extend `AppRuntimeSnapshot` with a new `theme` field and introduce `AppTheme` (`'light' | 'dark'`) in `src/app-runtime/AppRuntime.ts` and re-export `AppTheme` from `src/app-runtime/index.ts`.
- Add runtime storage and initialization via `initialTheme`, wire `theme` into `getSnapshot()`, and expose `getTheme()` and `setTheme(theme)` on `AppRuntime` with idempotent guard logic that only calls `emitSnapshot()` on actual changes.
- Update `src/app-runtime/AppRuntime.test.ts` to cover the default theme value, snapshot emission when theme changes, and the lack of duplicate emissions when `setTheme` is called with the same value.
- AI-native incremental refactor: applied — introduced explicit `AppTheme` and centralized theme-state with an idempotent setter to reduce duplicate reactive emissions and strengthen the `AppRuntime` boundary.

### Testing
- Added unit test cases in `src/app-runtime/AppRuntime.test.ts` for the new `theme` behavior (initial value, emission on change, no duplicate emissions).
- Attempted to run `npm run test -- src/app-runtime/AppRuntime.test.ts` but the test runner binary `vitest` was not available in the environment so tests could not be executed (error: `sh: 1: vitest: not found`).
- Attempted to install `vitest` with `npm i -D vitest` but the install failed due to registry access (`403 Forbidden`), so automated tests were not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d05133cf748331b33b93c10169297a)