### PR TITLE
bootstrap: sync document theme from AppRuntime snapshots

### DIFF
--- a/src/bootstrap/RuntimeHost.test.ts
+++ b/src/bootstrap/RuntimeHost.test.ts
@@ -66,6 +66,7 @@ vi.mock('../features/ai-assistant/services/AiAssistantCapabilities.ts', () => ({
 }));
 
 import { RuntimeHost } from './RuntimeHost.ts';
+import { createAppRuntime } from '../app-runtime/index.ts';
 import {
   TIME_CLUSTERING_LAYOUT_MODE_STORAGE_KEY,
   TIME_CLUSTERING_OVERLAP_WARNINGS_VISIBLE_STORAGE_KEY,
@@ -108,13 +109,13 @@ type MockResizeObserverClass = {
   new (callback: ResizeObserverCallback): ResizeObserver;
 };
 
-function createRuntimeHost(): RuntimeHost {
+function createRuntimeHost(runtime = createAppRuntime()): RuntimeHost {
   const wallpaper$ = new BehaviorSubject('');
   const wallpaperService = {
     wallpaper$: wallpaper$.asObservable(),
     wallpaperUrl: '',
   } as unknown as WallpaperService;
-  return new RuntimeHost(wallpaperService);
+  return new RuntimeHost(wallpaperService, runtime);
 }
 
 function getRuntimeHostInternals(host: RuntimeHost): RuntimeHostInternalAccess {
@@ -198,6 +199,21 @@ describe('RuntimeHost time clustering island layout', () => {
     document.body.innerHTML = '';
   });
 
+  it('syncs document theme from AppRuntime snapshots and unsubscribes on dispose', () => {
+    const runtime = createAppRuntime({ initialTheme: 'dark' });
+    const host = createRuntimeHost(runtime);
+
+    expect(document.documentElement.dataset.theme).toBe('dark');
+
+    runtime.setTheme('light');
+    expect(document.documentElement.dataset.theme).toBe('light');
+
+    host.dispose();
+
+    runtime.setTheme('dark');
+    expect(document.documentElement.dataset.theme).toBe('light');
+  });
+
   it('reserves left workspace space when time clustering is docked', () => {
     const host = getRuntimeHostInternals(createRuntimeHost());
     const { canvas } = attachCanvasSurface(host);
@@ -213,9 +229,7 @@ describe('RuntimeHost time clustering island layout', () => {
     expect(host.workspaceRoot.style.right).toBe('0px');
     expect(host.workspaceRoot.style.borderRadius).toBe('28px');
     expect(host.islandBackdropRoot.style.display).toBe('block');
-    expect(host.islandBackdropRoot.style.background).toBe(
-      'rgb(244, 248, 252)'
-    );
+    expect(host.islandBackdropRoot.style.background).toBe('rgb(244, 248, 252)');
     expect(host.timeClusteringIslandRoot.style.display).toBe('block');
     expect(host.timeClusteringIslandRoot.style.left).toBe('0px');
     expect(host.timeClusteringIslandRoot.style.width).toBe('360px');
@@ -248,9 +262,9 @@ describe('RuntimeHost time clustering island layout', () => {
 
   it('opens time clustering in docked-left mode without changing the base view', () => {
     const host = getRuntimeHostInternals(createRuntimeHost());
-    const show = vi.fn<(view: string) => Promise<void>>().mockResolvedValue(
-      undefined
-    );
+    const show = vi
+      .fn<(view: string) => Promise<void>>()
+      .mockResolvedValue(undefined);
     host.shell = {
       show,
       getActiveModule: () => null,
@@ -294,9 +308,9 @@ describe('RuntimeHost time clustering island layout', () => {
 
     host.handleTimeClusteringLayoutModeChange('fullscreen');
 
-    expect(
-      localStorage.getItem(TIME_CLUSTERING_LAYOUT_MODE_STORAGE_KEY)
-    ).toBe('fullscreen');
+    expect(localStorage.getItem(TIME_CLUSTERING_LAYOUT_MODE_STORAGE_KEY)).toBe(
+      'fullscreen'
+    );
     expect(host.timeClusteringLayoutMode).toBe('fullscreen');
 
     host.dispose();
@@ -317,9 +331,9 @@ describe('RuntimeHost time clustering island layout', () => {
 
   it('keeps docked-left time clustering open when switching the base view', async () => {
     const host = getRuntimeHostInternals(createRuntimeHost());
-    const show = vi.fn<(view: string) => Promise<void>>().mockResolvedValue(
-      undefined
-    );
+    const show = vi
+      .fn<(view: string) => Promise<void>>()
+      .mockResolvedValue(undefined);
     host.shell = {
       show,
       getActiveModule: () => null,
@@ -341,9 +355,9 @@ describe('RuntimeHost time clustering island layout', () => {
 
   it('closes fullscreen time clustering when switching the base view', async () => {
     const host = getRuntimeHostInternals(createRuntimeHost());
-    const show = vi.fn<(view: string) => Promise<void>>().mockResolvedValue(
-      undefined
-    );
+    const show = vi
+      .fn<(view: string) => Promise<void>>()
+      .mockResolvedValue(undefined);
     host.shell = {
       show,
       getActiveModule: () => null,
@@ -359,9 +373,9 @@ describe('RuntimeHost time clustering island layout', () => {
     expect(host.activeView).toBe('kanban');
     expect(host.timeClusteringOpen).toBe(false);
     expect(host.timeClusteringLayoutMode).toBe('docked-left');
-    expect(
-      localStorage.getItem(TIME_CLUSTERING_LAYOUT_MODE_STORAGE_KEY)
-    ).toBe('docked-left');
+    expect(localStorage.getItem(TIME_CLUSTERING_LAYOUT_MODE_STORAGE_KEY)).toBe(
+      'docked-left'
+    );
 
     host.dispose();
   });

--- a/src/bootstrap/RuntimeHost.ts
+++ b/src/bootstrap/RuntimeHost.ts
@@ -59,7 +59,11 @@ import { createAiAssistantRuntime } from '../features/ai-assistant/services/AiAs
 import { AiAssistantSessionController } from '../features/ai-assistant/services/AiAssistantSessionController.ts';
 import { buildAiAssistantCapabilityContext } from '../features/ai-assistant/services/AiAssistantCapabilities.ts';
 import type { TimeClusteringLayoutMode } from '../features/time-clustering/domain/types.ts';
-import { AppRuntime, createAppRuntime } from '../app-runtime/index.ts';
+import {
+  AppRuntime,
+  type AppRuntimeSnapshot,
+  createAppRuntime,
+} from '../app-runtime/index.ts';
 
 const TIME_CLUSTERING_ISLAND_WIDTH_PX = 360;
 
@@ -109,6 +113,7 @@ export class RuntimeHost {
   private readonly islandBackdropRoot: HTMLDivElement;
   private readonly wallpaperService: WallpaperService;
   private readonly wallpaperSubscription: Subscription;
+  private runtimeSubscriptionDispose: (() => void) | null = null;
   private currentWallpaperUrl = '';
   private readonly viewSwitcher: WorkspaceViewSwitcher;
   private readonly timeClusteringIslandRoot: HTMLDivElement;
@@ -191,6 +196,13 @@ export class RuntimeHost {
     );
     this.currentWallpaperUrl = this.wallpaperService.wallpaperUrl.trim();
     this.syncWorkspaceWallpaper();
+
+    this.runtimeSubscriptionDispose = this.runtime.subscribe(
+      (snapshot) => {
+        this.applyRuntimeSnapshot(snapshot);
+      },
+      { emitCurrent: true }
+    );
 
     this.timeClusteringOpen = loadPersistedTimeClusteringOpen(
       TIME_CLUSTERING_DEV_ENABLED
@@ -345,12 +357,18 @@ export class RuntimeHost {
     this.workspaceRoot.style.backgroundColor = '#e2e8f0';
   }
 
+  private applyRuntimeSnapshot(snapshot: AppRuntimeSnapshot): void {
+    document.documentElement.dataset.theme = snapshot.theme;
+  }
+
   public hideCanvas(): void {
     this.hostVisible = false;
     this.applyVisibility();
   }
 
   public dispose(): void {
+    this.runtimeSubscriptionDispose?.();
+    this.runtimeSubscriptionDispose = null;
     this.wallpaperSubscription.unsubscribe();
     if (this.layoutSyncTimer !== null) {
       window.clearTimeout(this.layoutSyncTimer);
@@ -724,11 +742,9 @@ export class RuntimeHost {
     }
 
     const workspaceLeftInset =
-      chrome.marginPx +
-      (hasLeftIsland ? leftIslandWidth + chrome.gapPx : 0);
+      chrome.marginPx + (hasLeftIsland ? leftIslandWidth + chrome.gapPx : 0);
     const workspaceRightInset =
-      chrome.marginPx +
-      (hasRightIsland ? chatWidth + chrome.gapPx : 0);
+      chrome.marginPx + (hasRightIsland ? chatWidth + chrome.gapPx : 0);
     const workspaceWidth = Math.max(
       320,
       window.innerWidth -
@@ -767,7 +783,8 @@ export class RuntimeHost {
     leftIslandWidth: number,
     chatWidth: number
   ): void {
-    const showBackdrop = showWorkspace && (leftIslandWidth > 0 || chatWidth > 0);
+    const showBackdrop =
+      showWorkspace && (leftIslandWidth > 0 || chatWidth > 0);
     this.islandBackdropRoot.style.display = showBackdrop ? 'block' : 'none';
   }
 


### PR DESCRIPTION
### Motivation
- Ensure the bootstrap host consumes theme exclusively from `AppRuntime` (no local theme flags) by subscribing with `emitCurrent: true` so the host immediately receives the current snapshot.
- Keep the document theme in sync with runtime snapshots so UI mode and CSS can react to theme changes consistently across mounted roots.
- Prevent runtime updates after unmount by cleaning up the subscription during destroy/dispose.

### Description
- Added a `runtimeSubscriptionDispose` field and a subscription in `RuntimeHost` constructor using `this.runtime.subscribe(..., { emitCurrent: true })` to receive snapshots immediately and on updates.
- Introduced `applyRuntimeSnapshot(snapshot: AppRuntimeSnapshot)` which sets `document.documentElement.dataset.theme = snapshot.theme` and is invoked from the runtime subscription.
- Ensure proper cleanup by calling `runtimeSubscriptionDispose?.()` and nulling the disposable in `dispose()` so the host no longer receives theme updates after teardown.
- Updated `src/bootstrap/RuntimeHost.test.ts` to add a focused test that verifies initial theme sync via `emitCurrent`, runtime-driven theme changes, and that no updates occur after `host.dispose()`, and adjusted the `createRuntimeHost` helper to accept an optional runtime for test injection.
- AI-native incremental refactor: applied; type: small extraction and explicit disposable management; what changed: extracted `applyRuntimeSnapshot` and added an explicit disposable field for the runtime subscription; boundary improved: clearer single source-of-truth for theme and safer teardown handling.

### Testing
- Attempted to run the unit test with `npm run test -- src/bootstrap/RuntimeHost.test.ts` but the environment reported `sh: 1: vitest: not found` so tests could not be executed here.
- Attempted a full build with `npm run build` but the build failed due to an unrelated unresolved import (`dompurify`) in `AiAssistantMarkdownRenderer.ts`, so the runtime integration could not be validated by build in this environment.
- Ran `npx prettier --write` to format changed files after edits; formatting completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d054582cc0833184519dd6ee1910ba)