### PR TITLE
Add semantic design tokens, dark-mode overrides and Tailwind token mappings

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,69 @@
 @import 'tailwindcss';
+
+:root {
+  /* surface */
+  --surface-canvas: #f8fafc;
+  --surface-base: #ffffff;
+  --surface-muted: #f5f6fa;
+  --surface-overlay: rgba(255, 255, 255, 0.96);
+
+  /* text */
+  --text-primary: #0f172a;
+  --text-secondary: #334155;
+  --text-muted: #64748b;
+  --text-inverse: #ffffff;
+
+  /* border */
+  --border-default: #e2e8f0;
+  --border-strong: #cbd5e1;
+  --border-focus: #93c5fd;
+
+  /* interactive */
+  --interactive-primary: #4a6dff;
+  --interactive-primary-hover: #6c8cff;
+  --interactive-primary-active: #3652b3;
+  --interactive-secondary: #e5e7eb;
+
+  /* status */
+  --status-danger: #ff4b4b;
+  --status-danger-hover: #ff7b7b;
+  --status-danger-active: #b91c1c;
+  --status-success: #16a34a;
+  --status-warning: #ffcb6b;
+}
+
+[data-theme='dark'] {
+  /* surface */
+  --surface-canvas: #09090b;
+  --surface-base: #0f172a;
+  --surface-muted: #1e293b;
+  --surface-overlay: rgba(15, 23, 42, 0.92);
+
+  /* text */
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5e1;
+  --text-muted: #94a3b8;
+  --text-inverse: #0f172a;
+
+  /* border */
+  --border-default: #334155;
+  --border-strong: #475569;
+  --border-focus: #60a5fa;
+
+  /* interactive */
+  --interactive-primary: #6c8cff;
+  --interactive-primary-hover: #a2bfff;
+  --interactive-primary-active: #4a6dff;
+  --interactive-secondary: #334155;
+
+  /* status */
+  --status-danger: #ff7b7b;
+  --status-danger-hover: #ffc1c1;
+  --status-danger-active: #ff4b4b;
+  --status-success: #22c55e;
+  --status-warning: #ffe9b3;
+}
+
 @theme {
   --color-primary: hsl(49, 100%, 7%);
   --font-display: 'Poppins', 'sans-serif';

--- a/src/styles.theme-smoke.test.ts
+++ b/src/styles.theme-smoke.test.ts
@@ -1,0 +1,46 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('theme semantic tokens smoke', () => {
+  beforeAll(() => {
+    const stylesPath = resolve(process.cwd(), 'src/styles.css');
+    const css = readFileSync(stylesPath, 'utf8');
+    const style = document.createElement('style');
+    style.textContent = css;
+    document.head.append(style);
+  });
+
+  it('switches root semantic palette when data-theme changes', () => {
+    const root = document.documentElement;
+
+    root.removeAttribute('data-theme');
+    const lightStyles = getComputedStyle(root);
+    const lightSurface = lightStyles
+      .getPropertyValue('--surface-base')
+      .trim()
+      .toLowerCase();
+    const lightText = lightStyles
+      .getPropertyValue('--text-primary')
+      .trim()
+      .toLowerCase();
+
+    root.setAttribute('data-theme', 'dark');
+    const darkStyles = getComputedStyle(root);
+    const darkSurface = darkStyles
+      .getPropertyValue('--surface-base')
+      .trim()
+      .toLowerCase();
+    const darkText = darkStyles
+      .getPropertyValue('--text-primary')
+      .trim()
+      .toLowerCase();
+
+    expect(lightSurface).toBe('#ffffff');
+    expect(darkSurface).toBe('#0f172a');
+    expect(lightText).toBe('#0f172a');
+    expect(darkText).toBe('#f8fafc');
+    expect(lightSurface).not.toBe(darkSurface);
+    expect(lightText).not.toBe(darkText);
+  });
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,45 +8,48 @@ module.exports = {
     extend: {
       colors: {
         primary: {
-          900: '#253A80', // darkest
-          800: '#3652B3',
-          700: '#4A6DFF', // DEFAULT, main blue
-          600: '#6C8CFF',
-          500: '#A2BFFF', // lightest
-          DEFAULT: '#4A6DFF', // Replit blue
-          foreground: '#FFFFFF',
+          900: 'var(--interactive-primary-active)',
+          800: 'var(--interactive-primary-active)',
+          700: 'var(--interactive-primary)', // DEFAULT, main interactive
+          600: 'var(--interactive-primary-hover)',
+          500: 'var(--interactive-primary-hover)',
+          DEFAULT: 'var(--interactive-primary)',
+          foreground: 'var(--text-inverse)',
         },
         destructive: {
-          900: '#991B1B',
-          800: '#B91C1C',
-          700: '#FF4B4B', // DEFAULT, main red
-          600: '#FF7B7B',
-          500: '#FFC1C1',
-          DEFAULT: '#FF4B4B', // Replit red
-          foreground: '#FFFFFF',
+          900: 'var(--status-danger-active)',
+          800: 'var(--status-danger-active)',
+          700: 'var(--status-danger)', // DEFAULT, danger role
+          600: 'var(--status-danger-hover)',
+          500: 'var(--status-danger-hover)',
+          DEFAULT: 'var(--status-danger)',
+          foreground: 'var(--text-inverse)',
         },
         secondary: {
-          900: '#A3A3A3',
-          800: '#C5C5C5',
-          700: '#E5E5E5',
-          600: '#F5F6FA', // DEFAULT, main gray
-          foreground: '#232323',
+          900: 'var(--border-strong)',
+          800: 'var(--border-default)',
+          700: 'var(--interactive-secondary)',
+          600: 'var(--surface-muted)', // DEFAULT, muted surface
+          foreground: 'var(--text-primary)',
         },
         accent: {
-          900: '#7B5E13',
-          800: '#B28A1C',
-          700: '#FFCB6B', // DEFAULT, main yellow
-          600: '#FFE9B3',
-          foreground: '#232323',
+          900: 'var(--status-warning)',
+          800: 'var(--status-warning)',
+          700: 'var(--status-warning)', // DEFAULT, warning role
+          600: 'var(--status-warning)',
+          foreground: 'var(--text-primary)',
         },
-        input: '#E3E3E3', // light border
-        background: '#232323', // dark bg
-        'destructive-foreground': '#FFFFFF',
-        'primary-foreground': '#FFFFFF',
-        'secondary-foreground': '#232323',
-        'accent-foreground': '#232323',
-        'muted-foreground': '#A0A0A0', // neutral gray for muted text
-        ring: '#4A6DFF',
+        input: 'var(--border-default)',
+        background: 'var(--surface-canvas)',
+        foreground: 'var(--text-primary)',
+        card: 'var(--surface-base)',
+        border: 'var(--border-default)',
+        'destructive-foreground': 'var(--text-inverse)',
+        'primary-foreground': 'var(--text-inverse)',
+        'secondary-foreground': 'var(--text-primary)',
+        'accent-foreground': 'var(--text-primary)',
+        'muted-foreground': 'var(--text-muted)',
+        ring: 'var(--border-focus)',
       },
     },
   },


### PR DESCRIPTION
### Motivation
- Centralize color roles into semantic CSS tokens so components use named roles instead of raw hex values.
- Enable runtime theme switching via `data-theme` without a full page reload and make Tailwind reflect the same semantic roles.

### Description
- Add semantic custom properties in `:root` for `surface`, `text`, `border`, `interactive`, and `status` roles in `src/styles.css`.
- Add `[data-theme='dark']` overrides in `src/styles.css` so the palette switches when `document.documentElement.dataset.theme` is changed.
- Remap key Tailwind color roles in `tailwind.config.js` to `var(--...)` token references so feature code can keep using semantic classes instead of raw hex values.
- Add a smoke test `src/styles.theme-smoke.test.ts` that injects `src/styles.css` into the test DOM and asserts token values change after toggling `data-theme`.
- AI-native incremental refactor: applied; type: semantic-token boundary hardening; what changed: centralized color roles into CSS custom properties and mapped Tailwind colors to those tokens; boundary improved: reduced raw-hex usage and made theme the single source of truth.

### Testing
- Added `src/styles.theme-smoke.test.ts` (smoke test) which verifies palette switches when toggling `data-theme` (test is present but not executed successfully in this environment).
- Attempted `npm run test -- src/styles.theme-smoke.test.ts` and it failed because the `vitest` executable was not available (`sh: 1: vitest: not found`).
- Attempted dependency install (`npm ci` / `npm install --include=dev`) in this environment but installation did not complete, so automated tests could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d055d963cc8331a2768697c300ebe6)