### PR TITLE
Add guidance on Canvas Relations vs Domain Relations in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,14 @@
 - The stored `ParentChild` relation normalizes that pair as `goal -> story`; UI affordances must not expose that storage direction as a separate reverse action.
 - A story may link to only one goal at a time; batch affordances must not offer one story -> many goals actions.
 
+### Canvas Relations vs Domain Relations Boundary
+
+- Treat canvas relations and domain relations as different systems with different responsibilities; never treat one as an alias of the other.
+- Canvas relations are visualization/runtime graph data for the canvas experience and should stay scoped to rendering-oriented interaction flows.
+- Domain relations are business-model data and must be persisted, validated, and reasoned about through explicit domain contracts.
+- Do not infer domain truth from canvas relation state, and do not use domain relation storage as a drop-in replacement for canvas visualization state.
+- If a feature needs both relation kinds, define a clear synchronization/projection contract with one declared source of truth per relation concern.
+
 ### Canvas Menu Boundaries
 
 - Treat `SelectionActionMenu` and `ContextMenu` as separate interaction systems with different UX goals and visual component needs.


### PR DESCRIPTION
### Motivation

- Clarify the intended boundaries between canvas-level relations (visualization/runtime) and domain-level relations (business model) to prevent incorrect coupling or inference of truth across systems.
- Provide explicit guidance for features that need both relation kinds so implementers declare a synchronization/projection contract and a single source of truth.

### Description

- Added a new section `Canvas Relations vs Domain Relations Boundary` to `AGENTS.md` that defines the two relation types and their responsibilities.
- The new guidance states that canvas relations are for rendering and runtime interaction while domain relations are persisted business-model data with explicit validation and contracts.
- The section prohibits treating one relation kind as an alias of the other and requires an explicit synchronization/projection contract with a declared source of truth when both are needed.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d01f6ec4e8833182ee459606298109)