### PR TITLE
Add semantic canvas theme palette and wire runtime theme to render pipeline

### DIFF
--- a/src/features/canvas/CanvasApp.themeRuntime.test.ts
+++ b/src/features/canvas/CanvasApp.themeRuntime.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createAppRuntime, type AppRuntimeSnapshot } from '../../app-runtime/index.ts';
+import { CanvasApp } from './CanvasApp.ts';
+
+type RuntimeThemeHarness = {
+  canvasManager: {
+    setCanvasRuntimeTheme: ReturnType<typeof vi.fn>;
+  };
+};
+
+function runRuntimeSnapshot(
+  app: RuntimeThemeHarness,
+  snapshot: AppRuntimeSnapshot
+): void {
+  (
+    CanvasApp.prototype as unknown as {
+      handleRuntimeSnapshot: (value: AppRuntimeSnapshot) => void;
+    }
+  ).handleRuntimeSnapshot.call(app, snapshot);
+}
+
+describe('CanvasApp runtime theme integration', () => {
+  it('updates the canvas palette when runtime theme changes', () => {
+    const runtime = createAppRuntime({ initialTheme: 'light' });
+    const app: RuntimeThemeHarness = {
+      canvasManager: {
+        setCanvasRuntimeTheme: vi.fn(),
+      },
+    };
+
+    runtime.subscribe((snapshot) => runRuntimeSnapshot(app, snapshot), {
+      emitCurrent: true,
+    });
+    runtime.setTheme('dark');
+
+    expect(app.canvasManager.setCanvasRuntimeTheme).toHaveBeenNthCalledWith(
+      1,
+      'light'
+    );
+    expect(app.canvasManager.setCanvasRuntimeTheme).toHaveBeenNthCalledWith(
+      2,
+      'dark'
+    );
+  });
+});

--- a/src/features/canvas/CanvasApp.ts
+++ b/src/features/canvas/CanvasApp.ts
@@ -72,7 +72,11 @@ import type {
   AiAssistantActionExecutionResult,
 } from '../ai-assistant/aiAssistantActions.ts';
 import type { I18nService } from '../../i18n/index.ts';
-import { AppRuntime, createAppRuntime } from '../../app-runtime/index.ts';
+import {
+  AppRuntime,
+  createAppRuntime,
+  type AppRuntimeSnapshot,
+} from '../../app-runtime/index.ts';
 import { Status } from '../../majom-wrapper/interfaces/index.ts';
 
 type CanvasListUiItem = {
@@ -117,6 +121,7 @@ export class CanvasApp {
   private viewChangesSubscription: Subscription | null = null;
   private sceneChangesSubscription: Subscription | null = null;
   private elementUpdateStatusSubscription: Subscription | null = null;
+  private disposeRuntimeSubscription: (() => void) | null = null;
   private destroyed = false;
   private readonly canvasListCache = new Map<string, CanvasListCacheItem>();
   private aiAssistantPreviousSnapshot: AiAssistantCanvasSnapshot | null = null;
@@ -157,6 +162,8 @@ export class CanvasApp {
     this.handleCanvasLinkLifecycle(event);
   private readonly canvasAutosaveToggledHandler = (event: Event): void =>
     this.handleCanvasAutosaveToggled(event);
+  private readonly runtimeSnapshotHandler = (snapshot: AppRuntimeSnapshot): void =>
+    this.handleRuntimeSnapshot(snapshot);
 
   constructor(
     dataProvider: IDataProvider,
@@ -177,6 +184,7 @@ export class CanvasApp {
 
     // Передаємо сцену в CanvasManager, щоб менеджер міг працювати з даними
     this.canvasManager = new CanvasManager(this.canvas, this.scene);
+    this.canvasManager.setCanvasRuntimeTheme(this.runtime.getTheme());
     // Використовуємо провайдера для створення репозиторію діаграми
     this.diagramRepository = new DiagramRepository(dataProvider);
     // Ініціалізація сервісу аутентифікації
@@ -365,6 +373,10 @@ export class CanvasApp {
       return;
     }
     this.stopAutosave();
+  }
+
+  private handleRuntimeSnapshot(snapshot: AppRuntimeSnapshot): void {
+    this.canvasManager.setCanvasRuntimeTheme(snapshot.theme);
   }
 
   private handleCanvasTitleEdited(event: Event): void {
@@ -791,6 +803,10 @@ export class CanvasApp {
       throw new Error('Cannot init destroyed App instance.');
     }
     this.canvasManager.init();
+    this.disposeRuntimeSubscription = this.runtime.subscribe(
+      this.runtimeSnapshotHandler,
+      { emitCurrent: true }
+    );
     // Restore last view state (scroll & zoom) via centralized setter
     const view: IViewState = await this.dataProvider.loadViewState();
     const panZoom = this.canvasManager.getPanZoomManager();
@@ -837,6 +853,8 @@ export class CanvasApp {
     this.sceneChangesSubscription = null;
     this.elementUpdateStatusSubscription?.unsubscribe();
     this.elementUpdateStatusSubscription = null;
+    this.disposeRuntimeSubscription?.();
+    this.disposeRuntimeSubscription = null;
     this.clearAiAssistantContext();
     this.uiManager.unmountAll();
     this.canvasManager.destroy();

--- a/src/features/canvas/core/constants.ts
+++ b/src/features/canvas/core/constants.ts
@@ -1,22 +1,24 @@
-// core/constants.ts
+import { DEFAULT_CANVAS_THEME } from '../theme/canvasTheme.ts';
+
+const palette = DEFAULT_CANVAS_THEME;
+
 // Unified color constant for selected and hover highlights across the canvas
-export const SELECT_COLOR = '#1d4ed8';
-export const FOCUS_COLOR = '#8b5cf6';
-export const HIGHLIGHT_COLOR = '#fa8c16';
-export const FOCUS_STORY_FILL = '#f1ecff';
-export const HIGHLIGHT_STORY_FILL = '#fff7ed';
-export const HOVER_OVERLAY_FILL = 'rgba(29,78,216,0.1)';
-export const HOVER_OUTLINE_COLOR = 'rgba(29,78,216,0.4)';
+export const SELECT_COLOR = palette.interaction.selection;
+export const FOCUS_COLOR = palette.interaction.focus;
+export const HIGHLIGHT_COLOR = palette.interaction.highlight;
+export const FOCUS_STORY_FILL = palette.interaction.storyFocusFill;
+export const HIGHLIGHT_STORY_FILL = palette.interaction.storyHighlightFill;
+export const HOVER_OVERLAY_FILL = palette.interaction.hoverOverlayFill;
+export const HOVER_OUTLINE_COLOR = palette.interaction.hoverOutline;
 // Region selection colors
-// export const REGION_SELECT_BORDER_COLOR = '#1890ff';
-export const REGION_SELECT_BORDER_COLOR = SELECT_COLOR;
-export const REGION_SELECT_FILL = 'rgba(29,78,216,0.2)';
-export const TASK_DROP_PLACEHOLDER_FILL = 'rgba(29,78,216,0.16)';
-export const SMART_GUIDE_COLOR = 'rgba(29,78,216,0.72)';
-export const SMART_GUIDE_SPACING_COLOR = 'rgba(13, 148, 136, 0.84)';
-export const SMART_GUIDE_CONTAINER_COLOR = 'rgba(245, 158, 11, 0.88)';
-export const SMART_GUIDE_VIEWPORT_CENTER_COLOR = 'rgba(14, 165, 233, 0.84)';
-export const SMART_GUIDE_LABEL_COLOR = '#0f172a';
+export const REGION_SELECT_BORDER_COLOR = palette.interaction.regionSelectionBorder;
+export const REGION_SELECT_FILL = palette.interaction.regionSelectionFill;
+export const TASK_DROP_PLACEHOLDER_FILL = palette.interaction.taskDropPlaceholderFill;
+export const SMART_GUIDE_COLOR = palette.guides.smartGuide;
+export const SMART_GUIDE_SPACING_COLOR = palette.guides.spacing;
+export const SMART_GUIDE_CONTAINER_COLOR = palette.guides.container;
+export const SMART_GUIDE_VIEWPORT_CENTER_COLOR = palette.guides.viewportCenter;
+export const SMART_GUIDE_LABEL_COLOR = palette.guides.label;
 export const SMART_GUIDE_LINE_WIDTH = 1.5;
 // Font settings
 export const FONT_FAMILY = 'Arial';

--- a/src/features/canvas/core/managers/CanvasManager.ts
+++ b/src/features/canvas/core/managers/CanvasManager.ts
@@ -16,18 +16,11 @@ import {
   type IConnection,
 } from '../interfaces/connection.ts';
 import {
-  SELECT_COLOR,
-  FOCUS_COLOR,
-  HOVER_OVERLAY_FILL,
-  HOVER_OUTLINE_COLOR,
-  REGION_SELECT_BORDER_COLOR,
-  REGION_SELECT_FILL,
   SHOW_DETAILS_SCALE,
   SHOW_GOAL_TEXT_SCALE,
   SHOW_STORY_TEXT_SCALE,
   SHOW_TASK_TEXT_SCALE,
   SHOW_ANIM_SCALE,
-  TASK_DROP_PLACEHOLDER_FILL,
 } from '../constants.ts';
 import { TaskElement } from '../../elements/TaskElement.ts';
 import { GoalElement } from '../../elements/GoalElement.ts';
@@ -48,6 +41,11 @@ import type {
   CanvasLoadPhase,
   CanvasLoadingPlaceholder,
 } from '../types/canvasLoading.ts';
+import {
+  DEFAULT_CANVAS_THEME,
+  resolveCanvasTheme,
+  type CanvasThemePalette,
+} from '../../theme/canvasTheme.ts';
 
 type CanvasLoadingPlaceholderRenderState = CanvasLoadingPlaceholder & {
   isFocused: boolean;
@@ -193,6 +191,7 @@ export class CanvasManager {
   private readonly perfSnapshotSubject: Subject<CanvasPerfSnapshot> =
     new Subject<CanvasPerfSnapshot>();
   public readonly perfSnapshot$ = this.perfSnapshotSubject.asObservable();
+  private canvasTheme: CanvasThemePalette = DEFAULT_CANVAS_THEME;
   private sceneChangesSubscription: Subscription | null = null;
   private sceneFocusChangesSubscription: Subscription | null = null;
   private sceneHighlightChangesSubscription: Subscription | null = null;
@@ -436,6 +435,7 @@ export class CanvasManager {
       showAnim: this.animationsEnabled && this.panZoom.scale >= SHOW_ANIM_SCALE,
       connectionAnimDetail: 'full',
       statusAnimDetail: 'full',
+      canvasTheme: this.canvasTheme,
     };
     if (this.backgroundCtx) {
       this.renderer.drawBackground(
@@ -605,7 +605,7 @@ export class CanvasManager {
       this.interactionManager.getTaskDropPlaceholders();
     if (taskDropPlaceholders.length > 0) {
       this.ctx.save();
-      this.ctx.fillStyle = TASK_DROP_PLACEHOLDER_FILL;
+      this.ctx.fillStyle = this.canvasTheme.interaction.taskDropPlaceholderFill;
       const radius = 24;
       taskDropPlaceholders.forEach((placeholder) => {
         this.ctx.beginPath();
@@ -634,8 +634,8 @@ export class CanvasManager {
           );
           if (!overlayGeometry) return;
           this.ctx.save();
-          this.ctx.fillStyle = HOVER_OVERLAY_FILL;
-          this.ctx.strokeStyle = HOVER_OUTLINE_COLOR;
+          this.ctx.fillStyle = this.canvasTheme.interaction.hoverOverlayFill;
+          this.ctx.strokeStyle = this.canvasTheme.interaction.hoverOutline;
           this.ctx.lineWidth = 2 / this.panZoom.scale;
           if (overlayGeometry.kind === 'circle') {
             this.ctx.beginPath();
@@ -678,7 +678,7 @@ export class CanvasManager {
       this.ctx.beginPath();
       this.ctx.moveTo(tempLine.startX, tempLine.startY);
       this.ctx.lineTo(tempLine.endX, tempLine.endY);
-      this.ctx.strokeStyle = '#000000';
+      this.ctx.strokeStyle = this.canvasTheme.interaction.tempConnectionLine;
       this.ctx.lineWidth = 2;
       this.ctx.setLineDash([5, 5]);
       this.ctx.globalAlpha = 0.5;
@@ -688,9 +688,9 @@ export class CanvasManager {
       this.ctx.save();
       this.ctx.beginPath();
       this.ctx.arc(tempLine.endX, tempLine.endY, 8, 0, 2 * Math.PI);
-      this.ctx.fillStyle = SELECT_COLOR;
+      this.ctx.fillStyle = this.canvasTheme.interaction.selection;
       this.ctx.fill();
-      this.ctx.strokeStyle = '#000000';
+      this.ctx.strokeStyle = this.canvasTheme.interaction.tempConnectionLine;
       this.ctx.lineWidth = 1;
       this.ctx.stroke();
       this.ctx.restore();
@@ -728,7 +728,7 @@ export class CanvasManager {
       const { minX, minY, maxX, maxY } = getBoundingBox(points);
       this.ctx.save();
       this.ctx.setLineDash([]);
-      this.ctx.strokeStyle = REGION_SELECT_BORDER_COLOR;
+      this.ctx.strokeStyle = this.canvasTheme.interaction.regionSelectionBorder;
       this.ctx.strokeRect(minX, minY, maxX - minX, maxY - minY);
       this.ctx.restore();
     }
@@ -737,9 +737,9 @@ export class CanvasManager {
     const region = this.interactionManager.getRegionRect();
     if (region) {
       this.ctx.save();
-      this.ctx.fillStyle = REGION_SELECT_FILL;
+      this.ctx.fillStyle = this.canvasTheme.interaction.regionSelectionFill;
       this.ctx.fillRect(region.x, region.y, region.width, region.height);
-      this.ctx.strokeStyle = REGION_SELECT_BORDER_COLOR;
+      this.ctx.strokeStyle = this.canvasTheme.interaction.regionSelectionBorder;
       this.ctx.setLineDash([]);
       this.ctx.strokeRect(region.x, region.y, region.width, region.height);
       this.ctx.restore();
@@ -816,7 +816,7 @@ export class CanvasManager {
 
     if (!placeholder.isFocused) return;
     this.ctx.save();
-    this.ctx.strokeStyle = FOCUS_COLOR;
+    this.ctx.strokeStyle = this.canvasTheme.interaction.focus;
     this.ctx.lineWidth = 2 / scale;
     this.ctx.setLineDash([]);
     this.ctx.beginPath();
@@ -1662,6 +1662,19 @@ export class CanvasManager {
 
   public getCanvas(): HTMLCanvasElement {
     return this.canvas;
+  }
+
+  public setCanvasTheme(theme: CanvasThemePalette): void {
+    this.canvasTheme = theme;
+    this.requestDraw();
+  }
+
+  public setCanvasRuntimeTheme(theme: 'light' | 'dark'): void {
+    this.setCanvasTheme(resolveCanvasTheme(theme));
+  }
+
+  public getCanvasTheme(): CanvasThemePalette {
+    return this.canvasTheme;
   }
 
   public getPanZoomManager(): PanZoomManager {

--- a/src/features/canvas/core/managers/PanZoomManager.ts
+++ b/src/features/canvas/core/managers/PanZoomManager.ts
@@ -1,6 +1,7 @@
 // managers/PanZoomManager.ts
 import { Subject } from 'rxjs';
 import type { IViewState } from '../interfaces/interfaces.ts';
+import type { CanvasThemePalette } from '../../theme/canvasTheme.ts';
 
 export type RenderFlags = {
   showDetails: boolean;
@@ -10,6 +11,7 @@ export type RenderFlags = {
   showAnim: boolean;
   connectionAnimDetail?: 'full' | 'reduced';
   statusAnimDetail?: 'full' | 'reduced';
+  canvasTheme?: CanvasThemePalette;
 };
 
 export class PanZoomManager {

--- a/src/features/canvas/elements/GoalElement.ts
+++ b/src/features/canvas/elements/GoalElement.ts
@@ -11,8 +11,9 @@ import {
 } from '../core/constants.ts';
 import { editElement$ } from '../core/eventBus.ts';
 import { v4 } from 'uuid';
-import { goalStyles } from './styles/goalStyles.ts';
+import { getGoalStyle } from './styles/goalStyles.ts';
 import { resolveGoalAppearance } from './styles/goalAppearance.ts';
+import { DEFAULT_CANVAS_THEME } from '../theme/canvasTheme.ts';
 import { ElementStatus } from './ElementStatus.ts';
 import { TextRenderer } from '../utils/TextRenderer.ts';
 import { drawStatusAnimationHex } from './utils/statusAnimations.ts';
@@ -38,7 +39,7 @@ export class GoalElement extends PlanningElement {
   links: string[] = [];
   progress: number = 0;
   public status: ElementStatus = ElementStatus.Defined;
-  public borderColor: string = goalStyles[ElementStatus.Defined].borderColor;
+  public borderColor: string = DEFAULT_CANVAS_THEME.nodes.goal.status.defined.border;
   public priority: UiPriority = 'low';
   public scale: GoalScale = DEFAULT_GOAL_SCALE;
 
@@ -89,7 +90,7 @@ export class GoalElement extends PlanningElement {
       y,
       width: diameter,
       height: diameter,
-      fillColor: goalStyles[status].fillColor,
+      fillColor: getGoalStyle(status, DEFAULT_CANVAS_THEME).fillColor,
       lineWidth: 2,
       title,
       tags,
@@ -99,7 +100,7 @@ export class GoalElement extends PlanningElement {
     });
     this.zIndex = 3;
     this.status = status;
-    this.borderColor = goalStyles[status].borderColor;
+    this.borderColor = getGoalStyle(status, DEFAULT_CANVAS_THEME).borderColor;
     this.priority = priority;
     this.selected = selected;
     this.description = description;
@@ -112,12 +113,13 @@ export class GoalElement extends PlanningElement {
       renderFlags?.showGoalText ?? panZoom.scale >= SHOW_GOAL_TEXT_SCALE;
     const showAnim = renderFlags?.showAnim ?? panZoom.scale >= SHOW_ANIM_SCALE;
     const { x, y, width, height, title } = this;
+    const canvasTheme = panZoom.renderFlags?.canvasTheme ?? DEFAULT_CANVAS_THEME;
     const appearance = resolveGoalAppearance({
       status: this.status,
       focused: this.focused,
       highlighted: this.highlighted,
       selected: this.selected,
-    });
+    }, canvasTheme);
     const strokeWidth = getPriorityStrokeWidth(this.priority) / panZoom.scale;
     this.fillColor = appearance.fillColor;
     this.borderColor = appearance.chromeColor;

--- a/src/features/canvas/elements/PlanningElement.ts
+++ b/src/features/canvas/elements/PlanningElement.ts
@@ -4,7 +4,7 @@ import { PanZoomManager } from '../core/managers/PanZoomManager.ts';
 import { ConnectionPoint } from '../core/interfaces/shape.ts';
 import { IPlanningElement } from './interfaces/planningElement.ts';
 import type { IConnectable } from '../core/interfaces/connectable.ts';
-import { SELECT_COLOR } from '../core/constants.ts';
+import { DEFAULT_CANVAS_THEME } from '../theme/canvasTheme.ts';
 
 export abstract class PlanningElement
   extends CanvasElement
@@ -106,8 +106,12 @@ export abstract class PlanningElement
         ctx.setLineDash([]);
         ctx.beginPath();
         ctx.arc(pt.x, pt.y, 4 / panZoom.scale, 0, 2 * Math.PI);
-        ctx.fillStyle = pt.isHovered ? SELECT_COLOR : '#ffffff';
-        ctx.strokeStyle = '#000000';
+        const canvasTheme =
+          panZoom.renderFlags?.canvasTheme ?? DEFAULT_CANVAS_THEME;
+        ctx.fillStyle = pt.isHovered
+          ? canvasTheme.anchors.hoverFill
+          : canvasTheme.anchors.fill;
+        ctx.strokeStyle = canvasTheme.anchors.border;
         ctx.lineWidth = 1 / panZoom.scale;
         ctx.fill();
         ctx.stroke();

--- a/src/features/canvas/elements/StoryElement.ts
+++ b/src/features/canvas/elements/StoryElement.ts
@@ -4,11 +4,6 @@ import { PanZoomManager } from '../core/managers/PanZoomManager.ts';
 import { TaskElement } from './TaskElement.ts';
 import { ConnectionPoint } from '../core/interfaces/shape.ts';
 import {
-  SELECT_COLOR,
-  FOCUS_COLOR,
-  HIGHLIGHT_COLOR,
-  FOCUS_STORY_FILL,
-  HIGHLIGHT_STORY_FILL,
   FONT_FAMILY,
   TITLE_FONT_SIZE,
   SMALL_FONT_SIZE,
@@ -17,7 +12,8 @@ import {
   SHOW_STORY_TEXT_SCALE,
 } from '../core/constants.ts';
 import { editElement$ } from '../core/eventBus.ts';
-import { storyStyles } from './styles/storyStyles.ts';
+import { getStoryStyle } from './styles/storyStyles.ts';
+import { DEFAULT_CANVAS_THEME } from '../theme/canvasTheme.ts';
 import { ElementStatus } from './ElementStatus.ts';
 import { v4 } from 'uuid';
 import { TextRenderer } from '../utils/TextRenderer.ts';
@@ -31,7 +27,7 @@ import { getPriorityStrokeWidth } from './utils/priorityStroke.ts';
 export class StoryElement extends PlanningElement {
   static width: number = 344;
   static height: number = 240;
-  public borderColor: string = storyStyles[ElementStatus.Defined].borderColor;
+  public borderColor: string = DEFAULT_CANVAS_THEME.nodes.story.status.defined.border;
   /** Size for resize handles (in px) */
   // Size in px for the circular resize handle (larger for better UX)
   static HANDLE_SIZE: number = 8;
@@ -78,7 +74,7 @@ export class StoryElement extends PlanningElement {
     goalBackendId?: number | null;
   }) {
     // determine style by status
-    const style = storyStyles[status];
+    const style = getStoryStyle(status, DEFAULT_CANVAS_THEME);
     super({
       id,
       x,
@@ -95,7 +91,7 @@ export class StoryElement extends PlanningElement {
     // layer ordering: draw stories below tasks
     this.zIndex = 1;
     this.status = status;
-    this.borderColor = storyStyles[status].borderColor;
+    this.borderColor = style.borderColor;
     this.priority = priority;
     this.tasks = tasks;
     this.selected = selected;
@@ -113,16 +109,17 @@ export class StoryElement extends PlanningElement {
       renderFlags?.showStoryText ?? panZoom.scale >= SHOW_STORY_TEXT_SCALE;
     const showAnim = renderFlags?.showAnim ?? panZoom.scale >= SHOW_ANIM_SCALE;
     // Apply fill and border based on status
-    const style = storyStyles[this.status];
+    const canvasTheme = panZoom.renderFlags?.canvasTheme ?? DEFAULT_CANVAS_THEME;
+    const style = getStoryStyle(this.status, canvasTheme);
     const chromeColor = this.focused
-      ? FOCUS_COLOR
+      ? canvasTheme.interaction.focus
       : this.highlighted
-        ? HIGHLIGHT_COLOR
+        ? canvasTheme.interaction.highlight
         : style.borderColor;
     const fillColor = this.focused
-      ? FOCUS_STORY_FILL
+      ? canvasTheme.interaction.storyFocusFill
       : this.highlighted
-        ? HIGHLIGHT_STORY_FILL
+        ? canvasTheme.interaction.storyHighlightFill
         : style.fillColor;
     const strokeWidth = getPriorityStrokeWidth(this.priority) / panZoom.scale;
     this.fillColor = fillColor;
@@ -137,11 +134,11 @@ export class StoryElement extends PlanningElement {
     const dashOff = 2 / panZoom.scale;
     ctx.setLineDash(this.selected ? [] : [dashOn, dashOff]);
     ctx.strokeStyle = this.focused
-      ? FOCUS_COLOR
+      ? canvasTheme.interaction.focus
       : this.highlighted
-        ? HIGHLIGHT_COLOR
+        ? canvasTheme.interaction.highlight
         : this.selected
-          ? SELECT_COLOR
+          ? canvasTheme.interaction.selection
           : style.borderColor;
     ctx.lineWidth = strokeWidth;
     ctx.stroke();
@@ -164,7 +161,7 @@ export class StoryElement extends PlanningElement {
     }
     if (showText) {
       // Title text with word wrapping
-      ctx.fillStyle = '#000000';
+      ctx.fillStyle = style.textColor;
       ctx.font = `bold ${TITLE_FONT_SIZE}px ${FONT_FAMILY}`;
       // Calculate max width for title, accounting for potential buttons
       const maxTitleWidth = this.width - 90; // Leave space for buttons on the right
@@ -192,7 +189,9 @@ export class StoryElement extends PlanningElement {
         ctx.beginPath();
         ctx.arc(h.x, h.y, size, 0, 2 * Math.PI);
 
-        ctx.fillStyle = isHandleHovered ? '#00A8FF' : SELECT_COLOR;
+        ctx.fillStyle = isHandleHovered
+          ? canvasTheme.handles.resizeHover
+          : canvasTheme.handles.resize;
         ctx.fill();
       });
     }

--- a/src/features/canvas/elements/TaskElement.ts
+++ b/src/features/canvas/elements/TaskElement.ts
@@ -2,14 +2,9 @@
 import { PlanningElement } from './PlanningElement.ts';
 import { PanZoomManager } from '../core/managers/PanZoomManager.ts';
 import { ConnectionPoint } from '../core/interfaces/shape.ts';
-import {
-  SELECT_COLOR,
-  FOCUS_COLOR,
-  HIGHLIGHT_COLOR,
-  SHOW_ANIM_SCALE,
-  SHOW_TASK_TEXT_SCALE,
-} from '../core/constants.ts';
-import { taskStyles } from './styles/taskStyles.ts';
+import { SHOW_ANIM_SCALE, SHOW_TASK_TEXT_SCALE } from '../core/constants.ts';
+import { getTaskStyle } from './styles/taskStyles.ts';
+import { DEFAULT_CANVAS_THEME } from '../theme/canvasTheme.ts';
 import { ElementStatus } from './ElementStatus.ts';
 import { editElement$ } from '../core/eventBus.ts';
 import { v4 } from 'uuid';
@@ -24,7 +19,7 @@ import { getPriorityStrokeWidth } from './utils/priorityStroke.ts';
 export class TaskElement extends PlanningElement {
   title: string;
   status: ElementStatus = ElementStatus.Defined;
-  public borderColor: string = taskStyles[ElementStatus.Defined].borderColor;
+  public borderColor: string = DEFAULT_CANVAS_THEME.nodes.task.status.defined.border;
   priority: UiPriority;
   dueDate: Date | null = null;
 
@@ -72,7 +67,7 @@ export class TaskElement extends PlanningElement {
     this.zIndex = 2;
     this.title = title;
     this.status = status;
-    this.borderColor = taskStyles[status].borderColor;
+    this.borderColor = DEFAULT_CANVAS_THEME.nodes.task.status[status].border;
     this.selected = selected;
     this.priority = priority;
     this.dueDate = dueDate ?? null;
@@ -91,11 +86,12 @@ export class TaskElement extends PlanningElement {
     const h = TaskElement.height;
     const strokeWidth = getPriorityStrokeWidth(this.priority) / panZoom.scale;
     // Background
-    const style = taskStyles[this.status];
+    const canvasTheme = panZoom.renderFlags?.canvasTheme ?? DEFAULT_CANVAS_THEME;
+    const style = getTaskStyle(this.status, canvasTheme);
     const chromeColor = this.focused
-      ? FOCUS_COLOR
+      ? canvasTheme.interaction.focus
       : this.highlighted
-        ? HIGHLIGHT_COLOR
+        ? canvasTheme.interaction.highlight
         : style.borderColor;
     this.fillColor = style.fillColor;
     this.borderColor = chromeColor;
@@ -106,11 +102,11 @@ export class TaskElement extends PlanningElement {
     ctx.roundRect(x, y, w, h, radius);
     ctx.fill();
     ctx.strokeStyle = this.focused
-      ? FOCUS_COLOR
+      ? canvasTheme.interaction.focus
       : this.highlighted
-        ? HIGHLIGHT_COLOR
+        ? canvasTheme.interaction.highlight
         : this.selected
-          ? SELECT_COLOR
+          ? canvasTheme.interaction.selection
           : style.borderColor;
     ctx.lineWidth = strokeWidth;
     ctx.lineJoin = 'round';
@@ -134,7 +130,7 @@ export class TaskElement extends PlanningElement {
     }
     if (showText) {
       // Title with word wrapping
-      ctx.fillStyle = '#000000';
+      ctx.fillStyle = style.textColor;
       ctx.font = `bold 14px Arial`;
 
       // Calculate maximum width for text with horizontal padding.
@@ -169,9 +165,11 @@ export class TaskElement extends PlanningElement {
         ctx.save();
         ctx.beginPath();
         ctx.arc(point.x, point.y, radius, 0, 2 * Math.PI);
-        ctx.fillStyle = isPortHovered ? SELECT_COLOR : '#ffffff';
+        ctx.fillStyle = isPortHovered
+          ? canvasTheme.anchors.hoverFill
+          : canvasTheme.anchors.fill;
         ctx.fill();
-        ctx.strokeStyle = '#000000';
+        ctx.strokeStyle = canvasTheme.anchors.border;
         ctx.lineWidth = 2;
         ctx.stroke();
         ctx.restore();

--- a/src/features/canvas/elements/constants.ts
+++ b/src/features/canvas/elements/constants.ts
@@ -1,34 +1,52 @@
+import { DEFAULT_CANVAS_THEME } from '../theme/canvasTheme.ts';
+
+const palette = DEFAULT_CANVAS_THEME;
+
 // Element-level style constants
 
 // Story status colors
-export const STORY_STATUS_DONE_FILL = 'rgba(82,196,26,0.03)';
-export const STORY_STATUS_DONE_BORDER = '#73d13d';
-export const STORY_STATUS_IN_PROGRESS_FILL = 'rgba(24,144,255,0.03)';
-export const STORY_STATUS_IN_PROGRESS_BORDER = '#1890ff';
-export const STORY_STATUS_PENDING_FILL = 'rgba(255,215,0,0.03)';
-export const STORY_STATUS_PENDING_BORDER = '#D1D100';
-export const STORY_STATUS_DEFINED_FILL = 'rgba(156,163,175,0.04)';
-export const STORY_STATUS_DEFINED_BORDER = '#BEAEBE';
+export const STORY_STATUS_DONE_FILL = palette.nodes.story.status.done.fill;
+export const STORY_STATUS_DONE_BORDER = palette.nodes.story.status.done.border;
+export const STORY_STATUS_IN_PROGRESS_FILL =
+  palette.nodes.story.status['in-progress'].fill;
+export const STORY_STATUS_IN_PROGRESS_BORDER =
+  palette.nodes.story.status['in-progress'].border;
+export const STORY_STATUS_PENDING_FILL =
+  palette.nodes.story.status.pending.fill;
+export const STORY_STATUS_PENDING_BORDER =
+  palette.nodes.story.status.pending.border;
+export const STORY_STATUS_DEFINED_FILL =
+  palette.nodes.story.status.defined.fill;
+export const STORY_STATUS_DEFINED_BORDER =
+  palette.nodes.story.status.defined.border;
 
 // Task status colors
-export const TASK_STATUS_DONE_FILL = '#ffffff';
-export const TASK_STATUS_DONE_BORDER = '#52c41a';
-export const TASK_STATUS_IN_PROGRESS_FILL = '#ffffff';
-export const TASK_STATUS_IN_PROGRESS_BORDER = '#1890ff';
-export const TASK_STATUS_PENDING_FILL = '#ffffff';
-export const TASK_STATUS_PENDING_BORDER = '#D1D100';
-export const TASK_STATUS_DEFINED_FILL = '#ffffff';
-export const TASK_STATUS_DEFINED_BORDER = '#BEAEBE';
+export const TASK_STATUS_DONE_FILL = palette.nodes.task.status.done.fill;
+export const TASK_STATUS_DONE_BORDER = palette.nodes.task.status.done.border;
+export const TASK_STATUS_IN_PROGRESS_FILL =
+  palette.nodes.task.status['in-progress'].fill;
+export const TASK_STATUS_IN_PROGRESS_BORDER =
+  palette.nodes.task.status['in-progress'].border;
+export const TASK_STATUS_PENDING_FILL = palette.nodes.task.status.pending.fill;
+export const TASK_STATUS_PENDING_BORDER =
+  palette.nodes.task.status.pending.border;
+export const TASK_STATUS_DEFINED_FILL = palette.nodes.task.status.defined.fill;
+export const TASK_STATUS_DEFINED_BORDER =
+  palette.nodes.task.status.defined.border;
 
 // Goal status colors
-export const GOAL_STATUS_DONE_FILL = '#36B37E';
-export const GOAL_STATUS_DONE_BORDER = '#0F8A63';
-export const GOAL_STATUS_IN_PROGRESS_FILL = '#5A9FF2';
-export const GOAL_STATUS_IN_PROGRESS_BORDER = '#2F7EEA';
-export const GOAL_STATUS_PENDING_FILL = '#F4D58D';
-export const GOAL_STATUS_PENDING_BORDER = '#D8A441';
-export const GOAL_STATUS_DEFINED_FILL = '#DDE7F0';
-export const GOAL_STATUS_DEFINED_BORDER = '#8FA3B8';
+export const GOAL_STATUS_DONE_FILL = palette.nodes.goal.status.done.fill;
+export const GOAL_STATUS_DONE_BORDER = palette.nodes.goal.status.done.border;
+export const GOAL_STATUS_IN_PROGRESS_FILL =
+  palette.nodes.goal.status['in-progress'].fill;
+export const GOAL_STATUS_IN_PROGRESS_BORDER =
+  palette.nodes.goal.status['in-progress'].border;
+export const GOAL_STATUS_PENDING_FILL = palette.nodes.goal.status.pending.fill;
+export const GOAL_STATUS_PENDING_BORDER =
+  palette.nodes.goal.status.pending.border;
+export const GOAL_STATUS_DEFINED_FILL = palette.nodes.goal.status.defined.fill;
+export const GOAL_STATUS_DEFINED_BORDER =
+  palette.nodes.goal.status.defined.border;
 
 // Habit state colors
 export const HABIT_ACTIVE_FILL = '#3B82F6';

--- a/src/features/canvas/elements/styles/goalAppearance.test.ts
+++ b/src/features/canvas/elements/styles/goalAppearance.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  FOCUS_COLOR,
-  HIGHLIGHT_COLOR,
-  SELECT_COLOR,
-} from '../../core/constants.ts';
+import { DEFAULT_CANVAS_THEME } from '../../theme/canvasTheme.ts';
 import { ElementStatus } from '../ElementStatus.ts';
 import { resolveGoalAppearance } from './goalAppearance.ts';
 
@@ -14,11 +10,11 @@ describe('resolveGoalAppearance', () => {
       focused: true,
       highlighted: false,
       selected: true,
-    });
+    }, DEFAULT_CANVAS_THEME);
 
     expect(appearance.fillColor).toBe('#a57aff');
-    expect(appearance.selectionStrokeColor).toBe(SELECT_COLOR);
-    expect(appearance.chromeColor).toBe(FOCUS_COLOR);
+    expect(appearance.selectionStrokeColor).toBe(DEFAULT_CANVAS_THEME.interaction.selection);
+    expect(appearance.chromeColor).toBe(DEFAULT_CANVAS_THEME.interaction.focus);
     expect(appearance.textColor).toBe('#f8fafc');
   });
 
@@ -28,11 +24,11 @@ describe('resolveGoalAppearance', () => {
       focused: false,
       highlighted: true,
       selected: true,
-    });
+    }, DEFAULT_CANVAS_THEME);
 
     expect(appearance.fillColor).toBe('#F2A03D');
-    expect(appearance.selectionStrokeColor).toBe(SELECT_COLOR);
-    expect(appearance.chromeColor).toBe(HIGHLIGHT_COLOR);
+    expect(appearance.selectionStrokeColor).toBe(DEFAULT_CANVAS_THEME.interaction.selection);
+    expect(appearance.chromeColor).toBe(DEFAULT_CANVAS_THEME.interaction.highlight);
     expect(appearance.textColor).toBe('#f8fafc');
   });
 
@@ -42,7 +38,7 @@ describe('resolveGoalAppearance', () => {
       focused: false,
       highlighted: false,
       selected: false,
-    });
+    }, DEFAULT_CANVAS_THEME);
 
     expect(appearance.fillColor).toBe('#5A9FF2');
     expect(appearance.selectionStrokeColor).toBeNull();

--- a/src/features/canvas/elements/styles/goalAppearance.ts
+++ b/src/features/canvas/elements/styles/goalAppearance.ts
@@ -1,15 +1,9 @@
-import {
-  FOCUS_COLOR,
-  HIGHLIGHT_COLOR,
-  SELECT_COLOR,
-} from '../../core/constants.ts';
 import { ElementStatus } from '../ElementStatus.ts';
-import { goalStyles } from './goalStyles.ts';
+import type { CanvasThemePalette } from '../../theme/canvasTheme.ts';
+import { getGoalStyle } from './goalStyles.ts';
 
 const GOAL_FOCUS_FILL = '#a57aff';
 const GOAL_HIGHLIGHT_FILL = '#F2A03D';
-const GOAL_TEXT_COLOR_LIGHT = '#f8fafc';
-const GOAL_TEXT_COLOR_DARK = '#0f172a';
 
 export type GoalAppearanceState = {
   status: ElementStatus;
@@ -25,35 +19,11 @@ export type GoalAppearance = {
   textColor: string;
 };
 
-function getHexChannelPair(value: string, startIndex: number): number | null {
-  const pair = value.slice(startIndex, startIndex + 2);
-  if (pair.length !== 2) return null;
-  const parsed = Number.parseInt(pair, 16);
-  return Number.isNaN(parsed) ? null : parsed;
-}
-
-function getGoalTextColor(fillColor: string): string {
-  if (!fillColor.startsWith('#') || fillColor.length !== 7) {
-    return GOAL_TEXT_COLOR_DARK;
-  }
-
-  const red = getHexChannelPair(fillColor, 1);
-  const green = getHexChannelPair(fillColor, 3);
-  const blue = getHexChannelPair(fillColor, 5);
-  if (red === null || green === null || blue === null) {
-    return GOAL_TEXT_COLOR_DARK;
-  }
-
-  const perceivedBrightness = (red * 299 + green * 587 + blue * 114) / 1000;
-  return perceivedBrightness < 150
-    ? GOAL_TEXT_COLOR_LIGHT
-    : GOAL_TEXT_COLOR_DARK;
-}
-
 export function resolveGoalAppearance(
-  state: GoalAppearanceState
+  state: GoalAppearanceState,
+  palette: CanvasThemePalette
 ): GoalAppearance {
-  const style = goalStyles[state.status];
+  const style = getGoalStyle(state.status, palette);
   const hasInteractionFill = state.focused || state.highlighted;
   const fillColor = state.focused
     ? GOAL_FOCUS_FILL
@@ -64,13 +34,11 @@ export function resolveGoalAppearance(
   return {
     fillColor,
     chromeColor: state.focused
-      ? FOCUS_COLOR
+      ? palette.interaction.focus
       : state.highlighted
-        ? HIGHLIGHT_COLOR
+        ? palette.interaction.highlight
         : style.borderColor,
-    selectionStrokeColor: state.selected ? SELECT_COLOR : null,
-    textColor: hasInteractionFill
-      ? GOAL_TEXT_COLOR_LIGHT
-      : getGoalTextColor(fillColor),
+    selectionStrokeColor: state.selected ? palette.interaction.selection : null,
+    textColor: hasInteractionFill ? '#f8fafc' : style.textColor,
   };
 }

--- a/src/features/canvas/elements/styles/goalStyles.ts
+++ b/src/features/canvas/elements/styles/goalStyles.ts
@@ -1,35 +1,20 @@
-import {
-  GOAL_STATUS_DONE_FILL,
-  GOAL_STATUS_DONE_BORDER,
-  GOAL_STATUS_IN_PROGRESS_FILL,
-  GOAL_STATUS_IN_PROGRESS_BORDER,
-  GOAL_STATUS_PENDING_FILL,
-  GOAL_STATUS_PENDING_BORDER,
-  GOAL_STATUS_DEFINED_FILL,
-  GOAL_STATUS_DEFINED_BORDER,
-} from '../constants.ts';
 import { ElementStatus } from '../ElementStatus.ts';
+import type { CanvasThemePalette } from '../../theme/canvasTheme.ts';
 
 export interface GoalStyle {
   fillColor: string;
   borderColor: string;
+  textColor: string;
 }
 
-export const goalStyles: Record<ElementStatus, GoalStyle> = {
-  done: {
-    fillColor: GOAL_STATUS_DONE_FILL,
-    borderColor: GOAL_STATUS_DONE_BORDER,
-  },
-  'in-progress': {
-    fillColor: GOAL_STATUS_IN_PROGRESS_FILL,
-    borderColor: GOAL_STATUS_IN_PROGRESS_BORDER,
-  },
-  pending: {
-    fillColor: GOAL_STATUS_PENDING_FILL,
-    borderColor: GOAL_STATUS_PENDING_BORDER,
-  },
-  defined: {
-    fillColor: GOAL_STATUS_DEFINED_FILL,
-    borderColor: GOAL_STATUS_DEFINED_BORDER,
-  },
-};
+export function getGoalStyle(
+  status: ElementStatus,
+  palette: CanvasThemePalette
+): GoalStyle {
+  const nodeStyle = palette.nodes.goal.status[status];
+  return {
+    fillColor: nodeStyle.fill,
+    borderColor: nodeStyle.border,
+    textColor: nodeStyle.text,
+  };
+}

--- a/src/features/canvas/elements/styles/storyStyles.ts
+++ b/src/features/canvas/elements/styles/storyStyles.ts
@@ -1,35 +1,20 @@
-import {
-  STORY_STATUS_DONE_FILL,
-  STORY_STATUS_DONE_BORDER,
-  STORY_STATUS_IN_PROGRESS_FILL,
-  STORY_STATUS_IN_PROGRESS_BORDER,
-  STORY_STATUS_PENDING_FILL,
-  STORY_STATUS_PENDING_BORDER,
-  STORY_STATUS_DEFINED_FILL,
-  STORY_STATUS_DEFINED_BORDER,
-} from '../constants.ts';
 import { ElementStatus } from '../ElementStatus.ts';
+import type { CanvasThemePalette } from '../../theme/canvasTheme.ts';
 
 export interface StoryStyle {
   fillColor: string;
   borderColor: string;
+  textColor: string;
 }
 
-export const storyStyles: Record<ElementStatus, StoryStyle> = {
-  done: {
-    fillColor: STORY_STATUS_DONE_FILL,
-    borderColor: STORY_STATUS_DONE_BORDER,
-  },
-  'in-progress': {
-    fillColor: STORY_STATUS_IN_PROGRESS_FILL,
-    borderColor: STORY_STATUS_IN_PROGRESS_BORDER,
-  },
-  pending: {
-    fillColor: STORY_STATUS_PENDING_FILL,
-    borderColor: STORY_STATUS_PENDING_BORDER,
-  },
-  defined: {
-    fillColor: STORY_STATUS_DEFINED_FILL,
-    borderColor: STORY_STATUS_DEFINED_BORDER,
-  },
-};
+export function getStoryStyle(
+  status: ElementStatus,
+  palette: CanvasThemePalette
+): StoryStyle {
+  const nodeStyle = palette.nodes.story.status[status];
+  return {
+    fillColor: nodeStyle.fill,
+    borderColor: nodeStyle.border,
+    textColor: nodeStyle.text,
+  };
+}

--- a/src/features/canvas/elements/styles/taskStyles.ts
+++ b/src/features/canvas/elements/styles/taskStyles.ts
@@ -1,35 +1,20 @@
-import {
-  TASK_STATUS_DONE_FILL,
-  TASK_STATUS_DONE_BORDER,
-  TASK_STATUS_IN_PROGRESS_FILL,
-  TASK_STATUS_IN_PROGRESS_BORDER,
-  TASK_STATUS_PENDING_FILL,
-  TASK_STATUS_PENDING_BORDER,
-  TASK_STATUS_DEFINED_FILL,
-  TASK_STATUS_DEFINED_BORDER,
-} from '../constants.ts';
 import { ElementStatus } from '../ElementStatus.ts';
+import type { CanvasThemePalette } from '../../theme/canvasTheme.ts';
 
 export interface TaskStyle {
   fillColor: string;
   borderColor: string;
+  textColor: string;
 }
 
-export const taskStyles: Record<ElementStatus, TaskStyle> = {
-  done: {
-    fillColor: TASK_STATUS_DONE_FILL,
-    borderColor: TASK_STATUS_DONE_BORDER,
-  },
-  'in-progress': {
-    fillColor: TASK_STATUS_IN_PROGRESS_FILL,
-    borderColor: TASK_STATUS_IN_PROGRESS_BORDER,
-  },
-  pending: {
-    fillColor: TASK_STATUS_PENDING_FILL,
-    borderColor: TASK_STATUS_PENDING_BORDER,
-  },
-  defined: {
-    fillColor: TASK_STATUS_DEFINED_FILL,
-    borderColor: TASK_STATUS_DEFINED_BORDER,
-  },
-};
+export function getTaskStyle(
+  status: ElementStatus,
+  palette: CanvasThemePalette
+): TaskStyle {
+  const nodeStyle = palette.nodes.task.status[status];
+  return {
+    fillColor: nodeStyle.fill,
+    borderColor: nodeStyle.border,
+    textColor: nodeStyle.text,
+  };
+}

--- a/src/features/canvas/theme/canvasTheme.ts
+++ b/src/features/canvas/theme/canvasTheme.ts
@@ -1,0 +1,173 @@
+import type { AppTheme } from '../../../app-runtime/index.ts';
+import { ElementStatus } from '../elements/ElementStatus.ts';
+
+export type CanvasNodeStatusPalette = {
+  fill: string;
+  border: string;
+  text: string;
+};
+
+export type CanvasNodePalette = {
+  status: Record<ElementStatus, CanvasNodeStatusPalette>;
+};
+
+export type CanvasThemePalette = {
+  nodes: {
+    task: CanvasNodePalette;
+    story: CanvasNodePalette;
+    goal: CanvasNodePalette;
+  };
+  interaction: {
+    selection: string;
+    focus: string;
+    highlight: string;
+    storyFocusFill: string;
+    storyHighlightFill: string;
+    hoverOverlayFill: string;
+    hoverOutline: string;
+    regionSelectionBorder: string;
+    regionSelectionFill: string;
+    taskDropPlaceholderFill: string;
+    tempConnectionLine: string;
+  };
+  anchors: {
+    fill: string;
+    border: string;
+    hoverFill: string;
+  };
+  handles: {
+    resize: string;
+    resizeHover: string;
+  };
+  guides: {
+    smartGuide: string;
+    spacing: string;
+    container: string;
+    viewportCenter: string;
+    label: string;
+  };
+};
+
+const lightPalette: CanvasThemePalette = {
+  nodes: {
+    story: {
+      status: {
+        done: { fill: 'rgba(82,196,26,0.03)', border: '#73d13d', text: '#000000' },
+        'in-progress': { fill: 'rgba(24,144,255,0.03)', border: '#1890ff', text: '#000000' },
+        pending: { fill: 'rgba(255,215,0,0.03)', border: '#D1D100', text: '#000000' },
+        defined: { fill: 'rgba(156,163,175,0.04)', border: '#BEAEBE', text: '#000000' },
+      },
+    },
+    task: {
+      status: {
+        done: { fill: '#ffffff', border: '#52c41a', text: '#000000' },
+        'in-progress': { fill: '#ffffff', border: '#1890ff', text: '#000000' },
+        pending: { fill: '#ffffff', border: '#D1D100', text: '#000000' },
+        defined: { fill: '#ffffff', border: '#BEAEBE', text: '#000000' },
+      },
+    },
+    goal: {
+      status: {
+        done: { fill: '#36B37E', border: '#0F8A63', text: '#f8fafc' },
+        'in-progress': { fill: '#5A9FF2', border: '#2F7EEA', text: '#f8fafc' },
+        pending: { fill: '#F4D58D', border: '#D8A441', text: '#0f172a' },
+        defined: { fill: '#DDE7F0', border: '#8FA3B8', text: '#0f172a' },
+      },
+    },
+  },
+  interaction: {
+    selection: '#1d4ed8',
+    focus: '#8b5cf6',
+    highlight: '#fa8c16',
+    storyFocusFill: '#f1ecff',
+    storyHighlightFill: '#fff7ed',
+    hoverOverlayFill: 'rgba(29,78,216,0.1)',
+    hoverOutline: 'rgba(29,78,216,0.4)',
+    regionSelectionBorder: '#1d4ed8',
+    regionSelectionFill: 'rgba(29,78,216,0.2)',
+    taskDropPlaceholderFill: 'rgba(29,78,216,0.16)',
+    tempConnectionLine: '#000000',
+  },
+  anchors: {
+    fill: '#ffffff',
+    border: '#000000',
+    hoverFill: '#1d4ed8',
+  },
+  handles: {
+    resize: '#1d4ed8',
+    resizeHover: '#00A8FF',
+  },
+  guides: {
+    smartGuide: 'rgba(29,78,216,0.72)',
+    spacing: 'rgba(13, 148, 136, 0.84)',
+    container: 'rgba(245, 158, 11, 0.88)',
+    viewportCenter: 'rgba(14, 165, 233, 0.84)',
+    label: '#0f172a',
+  },
+};
+
+const darkPalette: CanvasThemePalette = {
+  ...lightPalette,
+  nodes: {
+    story: {
+      status: {
+        done: { fill: 'rgba(82,196,26,0.12)', border: '#84cc16', text: '#f8fafc' },
+        'in-progress': { fill: 'rgba(24,144,255,0.12)', border: '#38bdf8', text: '#f8fafc' },
+        pending: { fill: 'rgba(255,215,0,0.13)', border: '#facc15', text: '#f8fafc' },
+        defined: { fill: 'rgba(148,163,184,0.16)', border: '#94a3b8', text: '#f8fafc' },
+      },
+    },
+    task: {
+      status: {
+        done: { fill: '#1f2937', border: '#84cc16', text: '#f8fafc' },
+        'in-progress': { fill: '#1f2937', border: '#38bdf8', text: '#f8fafc' },
+        pending: { fill: '#1f2937', border: '#facc15', text: '#f8fafc' },
+        defined: { fill: '#1f2937', border: '#94a3b8', text: '#f8fafc' },
+      },
+    },
+    goal: {
+      status: {
+        done: { fill: '#0f766e', border: '#2dd4bf', text: '#f8fafc' },
+        'in-progress': { fill: '#1d4ed8', border: '#60a5fa', text: '#f8fafc' },
+        pending: { fill: '#b45309', border: '#f59e0b', text: '#f8fafc' },
+        defined: { fill: '#334155', border: '#94a3b8', text: '#f8fafc' },
+      },
+    },
+  },
+  interaction: {
+    ...lightPalette.interaction,
+    selection: '#60a5fa',
+    focus: '#a78bfa',
+    highlight: '#fb923c',
+    storyFocusFill: '#312e81',
+    storyHighlightFill: '#7c2d12',
+    hoverOverlayFill: 'rgba(96,165,250,0.18)',
+    hoverOutline: 'rgba(96,165,250,0.52)',
+    regionSelectionBorder: '#60a5fa',
+    regionSelectionFill: 'rgba(96,165,250,0.22)',
+    taskDropPlaceholderFill: 'rgba(96,165,250,0.22)',
+    tempConnectionLine: '#e2e8f0',
+  },
+  anchors: {
+    fill: '#0f172a',
+    border: '#e2e8f0',
+    hoverFill: '#60a5fa',
+  },
+  handles: {
+    resize: '#60a5fa',
+    resizeHover: '#93c5fd',
+  },
+  guides: {
+    smartGuide: 'rgba(96,165,250,0.86)',
+    spacing: 'rgba(45, 212, 191, 0.86)',
+    container: 'rgba(251, 191, 36, 0.9)',
+    viewportCenter: 'rgba(56, 189, 248, 0.88)',
+    label: '#f8fafc',
+  },
+};
+
+export const DEFAULT_CANVAS_THEME = lightPalette;
+
+export function resolveCanvasTheme(theme: AppTheme): CanvasThemePalette {
+  return theme === 'dark' ? darkPalette : lightPalette;
+}


### PR DESCRIPTION
### Motivation

- Provide a single typed source of truth for canvas colors and semantic roles so elements and render pipeline stop using scattered hardcoded color constants.
- Allow the app `runtime.theme` to update the canvas palette at runtime so light/dark switches immediately affect canvas rendering.

### Description

- Add a semantic palette module `src/features/canvas/theme/canvasTheme.ts` with typed roles for node status (task/story/goal fill/border/text), interaction (selection/focus/highlight/etc.), anchors/handles/guides, and implement `resolveCanvasTheme(theme)` for `light`/`dark` themes.
- Replace legacy constants by sourcing values from the semantic palette in `src/features/canvas/core/constants.ts` and `src/features/canvas/elements/constants.ts` and convert element style helpers to palette-driven functions (`getTaskStyle`, `getStoryStyle`, `getGoalStyle`) in `src/features/canvas/elements/styles/*`.
- Wire the palette into the render pipeline: `CanvasManager` now owns `canvasTheme`, exposes `setCanvasTheme`/`setCanvasRuntimeTheme`/`getCanvasTheme`, injects the theme into `panZoom.renderFlags.canvasTheme`, and uses it for overlays, anchors, handles, region selection, temp-lines and related rendering paths.
- Update element rendering (`TaskElement`, `StoryElement`, `GoalElement`, `PlanningElement`) to consume the runtime palette via `panZoom.renderFlags.canvasTheme` (fallback to `DEFAULT_CANVAS_THEME`) instead of hardcoded colors.
- Connect `AppRuntime` theme snapshots to the canvas by subscribing inside `CanvasApp` and forwarding theme updates to `CanvasManager`; add an integration regression test `src/features/canvas/CanvasApp.themeRuntime.test.ts` verifying the runtime -> canvas update path.

### Testing

- Added an integration regression test `src/features/canvas/CanvasApp.themeRuntime.test.ts` that asserts runtime snapshot emission triggers canvas runtime theme updates and the test file is present in the commit (not executed to completion here due to environment limitations).
- Attempted to run the test command `npm run test -- src/features/canvas/CanvasApp.themeRuntime.test.ts src/features/canvas/elements/styles/goalAppearance.test.ts` but `vitest` was not available in the execution environment and the run failed with `sh: 1: vitest: not found`.
- Performed a TypeScript compile check with `tsc --noEmit` which failed in the environment due to missing ambient type definitions (`chai`, `deep-eql`, `json-schema`, `trusted-types`), indicating local dependency/type setup is required before full CI/test success.
- Source changes were lint/compile checked locally where possible and the new test was added to the repo for CI to run in the normal environment where dev dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d058de16d883319d7e53e1ea45ac13)