### PR TITLE
Use canvas theme roles for goal/story draw colors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,11 @@
 - Do not infer domain truth from canvas relation state, and do not use domain relation storage as a drop-in replacement for canvas visualization state.
 - If a feature needs both relation kinds, define a clear synchronization/projection contract with one declared source of truth per relation concern.
 
+### Canvas Draw Color Roles
+
+- For canvas element `draw()` methods, do not introduce raw hex colors directly in rendering branches.
+- Resolve colors through `canvasTheme` roles (node status roles, interaction roles, anchors/handles/guides roles, or dedicated new roles added to the theme palette).
+
 ### Canvas Menu Boundaries
 
 - Treat `SelectionActionMenu` and `ContextMenu` as separate interaction systems with different UX goals and visual component needs.

--- a/src/features/canvas/elements/StoryElement.ts
+++ b/src/features/canvas/elements/StoryElement.ts
@@ -218,8 +218,9 @@ export class StoryElement extends PlanningElement {
       ctx.fill();
     }
 
+    const canvasTheme = panZoom.renderFlags?.canvasTheme ?? DEFAULT_CANVAS_THEME;
     // Icon
-    ctx.fillStyle = '#666666';
+    ctx.fillStyle = canvasTheme.interaction.iconMuted;
     ctx.font = `${SMALL_FONT_SIZE / panZoom.scale}px ${FONT_FAMILY}`;
     ctx.fillText(icon, x + 3 / panZoom.scale, y + 16 / panZoom.scale);
   }

--- a/src/features/canvas/elements/styles/goalAppearance.test.ts
+++ b/src/features/canvas/elements/styles/goalAppearance.test.ts
@@ -1,7 +1,29 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_CANVAS_THEME } from '../../theme/canvasTheme.ts';
+import { DEFAULT_CANVAS_THEME, resolveCanvasTheme, type CanvasThemePalette } from '../../theme/canvasTheme.ts';
 import { ElementStatus } from '../ElementStatus.ts';
 import { resolveGoalAppearance } from './goalAppearance.ts';
+
+function getHexChannelPair(value: string, startIndex: number): number {
+  return Number.parseInt(value.slice(startIndex, startIndex + 2), 16);
+}
+
+function getRelativeLuminance(hexColor: string): number {
+  const red = getHexChannelPair(hexColor, 1) / 255;
+  const green = getHexChannelPair(hexColor, 3) / 255;
+  const blue = getHexChannelPair(hexColor, 5) / 255;
+  const toLinear = (channel: number): number =>
+    channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+
+  return 0.2126 * toLinear(red) + 0.7152 * toLinear(green) + 0.0722 * toLinear(blue);
+}
+
+function getContrastRatio(foreground: string, background: string): number {
+  const foregroundL = getRelativeLuminance(foreground);
+  const backgroundL = getRelativeLuminance(background);
+  const lighter = Math.max(foregroundL, backgroundL);
+  const darker = Math.min(foregroundL, backgroundL);
+  return (lighter + 0.05) / (darker + 0.05);
+}
 
 describe('resolveGoalAppearance', () => {
   it('keeps the selected outline when a goal is focused', () => {
@@ -12,10 +34,10 @@ describe('resolveGoalAppearance', () => {
       selected: true,
     }, DEFAULT_CANVAS_THEME);
 
-    expect(appearance.fillColor).toBe('#a57aff');
+    expect(appearance.fillColor).toBe(DEFAULT_CANVAS_THEME.interaction.goalFocusFill);
     expect(appearance.selectionStrokeColor).toBe(DEFAULT_CANVAS_THEME.interaction.selection);
     expect(appearance.chromeColor).toBe(DEFAULT_CANVAS_THEME.interaction.focus);
-    expect(appearance.textColor).toBe('#f8fafc');
+    expect(appearance.textColor).toBe(DEFAULT_CANVAS_THEME.interaction.goalFocusText);
   });
 
   it('keeps the selected outline when a goal is highlighted', () => {
@@ -26,13 +48,13 @@ describe('resolveGoalAppearance', () => {
       selected: true,
     }, DEFAULT_CANVAS_THEME);
 
-    expect(appearance.fillColor).toBe('#F2A03D');
+    expect(appearance.fillColor).toBe(DEFAULT_CANVAS_THEME.interaction.goalHighlightFill);
     expect(appearance.selectionStrokeColor).toBe(DEFAULT_CANVAS_THEME.interaction.selection);
     expect(appearance.chromeColor).toBe(DEFAULT_CANVAS_THEME.interaction.highlight);
-    expect(appearance.textColor).toBe('#f8fafc');
+    expect(appearance.textColor).toBe(DEFAULT_CANVAS_THEME.interaction.goalHighlightText);
   });
 
-  it('uses the status fill and readable text color outside interaction states', () => {
+  it('uses the status fill and status text color outside interaction states', () => {
     const appearance = resolveGoalAppearance({
       status: ElementStatus.InProgress,
       focused: false,
@@ -42,6 +64,25 @@ describe('resolveGoalAppearance', () => {
 
     expect(appearance.fillColor).toBe('#5A9FF2');
     expect(appearance.selectionStrokeColor).toBeNull();
-    expect(appearance.textColor).toBe('#f8fafc');
+    expect(appearance.textColor).toBe(DEFAULT_CANVAS_THEME.nodes.goal.status[ElementStatus.InProgress].text);
+  });
+
+  it.each([
+    ['light', DEFAULT_CANVAS_THEME],
+    ['dark', resolveCanvasTheme('dark')],
+  ])('keeps readable focus/highlight text contrast in %s theme', (_themeName, palette: CanvasThemePalette) => {
+    const focused = resolveGoalAppearance(
+      { status: ElementStatus.Defined, focused: true, highlighted: false, selected: true },
+      palette
+    );
+    const highlighted = resolveGoalAppearance(
+      { status: ElementStatus.Defined, focused: false, highlighted: true, selected: true },
+      palette
+    );
+
+    expect(getContrastRatio(focused.textColor, focused.fillColor)).toBeGreaterThanOrEqual(4.5);
+    expect(getContrastRatio(highlighted.textColor, highlighted.fillColor)).toBeGreaterThanOrEqual(4.5);
+    expect(getContrastRatio(palette.interaction.selection, focused.fillColor)).toBeGreaterThanOrEqual(2);
+    expect(getContrastRatio(palette.interaction.selection, highlighted.fillColor)).toBeGreaterThanOrEqual(2);
   });
 });

--- a/src/features/canvas/elements/styles/goalAppearance.ts
+++ b/src/features/canvas/elements/styles/goalAppearance.ts
@@ -2,9 +2,6 @@ import { ElementStatus } from '../ElementStatus.ts';
 import type { CanvasThemePalette } from '../../theme/canvasTheme.ts';
 import { getGoalStyle } from './goalStyles.ts';
 
-const GOAL_FOCUS_FILL = '#a57aff';
-const GOAL_HIGHLIGHT_FILL = '#F2A03D';
-
 export type GoalAppearanceState = {
   status: ElementStatus;
   focused: boolean;
@@ -24,11 +21,10 @@ export function resolveGoalAppearance(
   palette: CanvasThemePalette
 ): GoalAppearance {
   const style = getGoalStyle(state.status, palette);
-  const hasInteractionFill = state.focused || state.highlighted;
   const fillColor = state.focused
-    ? GOAL_FOCUS_FILL
+    ? palette.interaction.goalFocusFill
     : state.highlighted
-      ? GOAL_HIGHLIGHT_FILL
+      ? palette.interaction.goalHighlightFill
       : style.fillColor;
 
   return {
@@ -39,6 +35,10 @@ export function resolveGoalAppearance(
         ? palette.interaction.highlight
         : style.borderColor,
     selectionStrokeColor: state.selected ? palette.interaction.selection : null,
-    textColor: hasInteractionFill ? '#f8fafc' : style.textColor,
+    textColor: state.focused
+      ? palette.interaction.goalFocusText
+      : state.highlighted
+        ? palette.interaction.goalHighlightText
+        : style.textColor,
   };
 }

--- a/src/features/canvas/theme/canvasTheme.ts
+++ b/src/features/canvas/theme/canvasTheme.ts
@@ -23,6 +23,11 @@ export type CanvasThemePalette = {
     highlight: string;
     storyFocusFill: string;
     storyHighlightFill: string;
+    goalFocusFill: string;
+    goalHighlightFill: string;
+    goalFocusText: string;
+    goalHighlightText: string;
+    iconMuted: string;
     hoverOverlayFill: string;
     hoverOutline: string;
     regionSelectionBorder: string;
@@ -81,6 +86,11 @@ const lightPalette: CanvasThemePalette = {
     highlight: '#fa8c16',
     storyFocusFill: '#f1ecff',
     storyHighlightFill: '#fff7ed',
+    goalFocusFill: '#a57aff',
+    goalHighlightFill: '#F2A03D',
+    goalFocusText: '#0f172a',
+    goalHighlightText: '#0f172a',
+    iconMuted: '#666666',
     hoverOverlayFill: 'rgba(29,78,216,0.1)',
     hoverOutline: 'rgba(29,78,216,0.4)',
     regionSelectionBorder: '#1d4ed8',
@@ -141,6 +151,11 @@ const darkPalette: CanvasThemePalette = {
     highlight: '#fb923c',
     storyFocusFill: '#312e81',
     storyHighlightFill: '#7c2d12',
+    goalFocusFill: '#7c3aed',
+    goalHighlightFill: '#c2410c',
+    goalFocusText: '#f8fafc',
+    goalHighlightText: '#f8fafc',
+    iconMuted: '#cbd5e1',
     hoverOverlayFill: 'rgba(96,165,250,0.18)',
     hoverOutline: 'rgba(96,165,250,0.52)',
     regionSelectionBorder: '#60a5fa',


### PR DESCRIPTION
### Motivation
- Replace hard-coded hex colors used by goal and story draw logic with centralized theme roles so canvas elements source colors from `canvasTheme` and maintain consistent behavior across light/dark modes.
- Ensure focused/highlighted/selected states produce accessible text contrast and prevent new canvas draw methods from introducing raw hex values.

### Description
- Replaced local `GOAL_FOCUS_FILL/GOAL_HIGHLIGHT_FILL` and interaction text fallback in `resolveGoalAppearance` to use `palette.interaction.goalFocusFill`, `goalHighlightFill`, `goalFocusText`, and `goalHighlightText` from the canvas theme; updated `resolveGoalAppearance` signature to accept the palette. (files: `src/features/canvas/elements/styles/goalAppearance.ts`)
- Extended `CanvasThemePalette` with `goalFocusFill`, `goalHighlightFill`, `goalFocusText`, `goalHighlightText`, and `iconMuted`, and populated values for both light and dark palettes. (file: `src/features/canvas/theme/canvasTheme.ts`)
- Replaced the hard-coded icon color in `StoryElement.drawButton()` with `canvasTheme.interaction.iconMuted`. (file: `src/features/canvas/elements/StoryElement.ts`)
- Added/updated unit tests to assert theme-driven goal appearance and contrast for focused/highlighted states in both light and dark themes. (file: `src/features/canvas/elements/styles/goalAppearance.test.ts`)
- Documented a project rule in `AGENTS.md` enforcing that canvas `draw()` methods must not introduce raw hex colors and should use `canvasTheme` roles. (file: `AGENTS.md`)
- Note: `TaskElement.draw()` already consumes theme roles for anchors/text/interaction; its constructor default `fillColor` still had `#ffffff` and was intentionally left unchanged because the change targeted draw/appearance logic only. (file: `src/features/canvas/elements/TaskElement.ts`)

### Testing
- Added contrast-oriented tests in `src/features/canvas/elements/styles/goalAppearance.test.ts` and attempted to run them, but `vitest` is not available in the current environment so automated test runs could not complete. (result: test runner not found / registry access blocked)
- Performed local static checks: searched for remaining raw hex occurrences related to this change with `rg` and verified relevant draw branches were switched to theme roles. (result: success)
- All changes were committed locally with message "Use canvas theme roles for goal/story draw colors".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d05e9370308331a45b236881e0d5c7)